### PR TITLE
Add a LOCAL_IMAGE var to makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,21 @@
+LOCAL_IMAGE=openshift-spark
 SPARK_IMAGE=mattf/openshift-spark
+
+# If you're pushing to an integrated registry
+# in Openshift, SPARK_IMAGE will look something like this
+
+# SPARK_IMAGE=172.30.242.71:5000/myproject/openshift-spark
 
 .PHONY: build clean push create destroy
 
 build:
-	docker build -t openshift-spark .
+	docker build -t $(LOCAL_IMAGE) .
 
 clean:
-	docker rmi openshift-spark
+	docker rmi $(LOCAL_IMAGE)
 
 push: build
-	docker tag -f openshift-spark $(SPARK_IMAGE)
+	docker tag -f $(LOCAL_IMAGE) $(SPARK_IMAGE)
 	docker push $(SPARK_IMAGE)
 
 create: push template.yaml


### PR DESCRIPTION
This makes it easier to set the local image name so that
builds associated with different projects in the same local
docker instance can be distinguished, for example
myproject/openshift-spark vs yourproject/openshift-spark