### PR TITLE
Add a Makefile for generating an openshift-spark based on py s2i

### DIFF
--- a/openshift-spark-py27-sti/Makefile
+++ b/openshift-spark-py27-sti/Makefile
@@ -1,5 +1,5 @@
 BASE_IMAGE=centos/python-27-centos7:latest
-LOCAL_IMAGE=openshift-spark-py27i-sti
+LOCAL_IMAGE=openshift-spark-py27-sti
 SPARK_IMAGE=myproject/openshift-spark-py27-sti
 
 .PHONY: build clean push create destroy artifacts clean-artifacts clean-dockerfile clean-scripts clean-template

--- a/openshift-spark-py27-sti/Makefile
+++ b/openshift-spark-py27-sti/Makefile
@@ -1,6 +1,10 @@
 BASE_IMAGE=centos/python-27-centos7:latest
 LOCAL_IMAGE=openshift-spark-py27-sti
-SPARK_IMAGE=myproject/openshift-spark-py27-sti
+
+# If you are going to push the built image to a registry
+# using the "push" make target then you should replace
+# "project" with an appropriate path for your registry and/or project
+SPARK_IMAGE=project/openshift-spark-py27-sti
 
 .PHONY: build clean push create destroy artifacts clean-artifacts clean-dockerfile clean-scripts clean-template
 

--- a/openshift-spark-py27-sti/README.md
+++ b/openshift-spark-py27-sti/README.md
@@ -12,8 +12,11 @@ the parent directory contain the same version of spark.
 
 ## How to use this Makefile
 
-The `clean`, `build`, `create`, and `destroy` targets are analagous
+The `clean`, `build`, `push`, `create`, and `destroy` targets are analagous
 to the targets in the parent directory's Makefile.
+
+By default the `push` target will tag the image as `project/openshift-spark-py27-sti`,
+edit the Makefile and change `SPARK_IAMGE` to control this.
 
 However, files must be copied from the parent directory before the
 image may be built. To do this use `make artifacts`:

--- a/openshift-spark-py27-sti/README.md
+++ b/openshift-spark-py27-sti/README.md
@@ -1,0 +1,31 @@
+# openshift-spark-py27-sti
+
+The Makefile in this directory builds an openshift-spark image based
+on the standard python27 s2i image (centos/python-27-centos7).
+
+It does this by copying files from the parent directory and modifying
+the ``FROM`` field in the local Dockerfile before building. The motivation
+is to provide a python s2i builder which has Apache Spark installed
+without having to manually maintain the Spark installation commands and
+to guarantee that this image and an openshift-spark image built in
+the parent directory contain the same version of spark.
+
+## How to use this Makefile
+
+The `clean`, `build`, `create`, and `destroy` targets are analagous
+to the targets in the parent directory's Makefile.
+
+However, files must be copied from the parent directory before the
+image may be built. To do this use `make artifacts`:
+
+```
+    $ make artifacts
+    $ sudo make push
+```
+
+To refresh the files copied from the parent directory:
+
+```
+    $ make clean-artifacts
+    $ make artifacts
+```

--- a/python27_sti_base/Makefile
+++ b/python27_sti_base/Makefile
@@ -1,0 +1,46 @@
+BASE_IMAGE=centos/python-27-centos7:latest
+LOCAL_IMAGE=openshift-spark-py27i-sti
+SPARK_IMAGE=myproject/openshift-spark-py27-sti
+
+.PHONY: build clean push create destroy artifacts clean-artifacts clean-dockerfile clean-scripts clean-template
+
+build:
+	docker build -t $(LOCAL_IMAGE) .
+
+clean:
+	- docker rmi $(LOCAL_IMAGE)
+
+push: build
+	docker tag -f $(LOCAL_IMAGE) $(SPARK_IMAGE)
+	docker push $(SPARK_IMAGE)
+
+create: template.yaml
+	oc process -f template.yaml -v SPARK_IMAGE=$(SPARK_IMAGE) > template.active
+	oc create -f template.active
+
+destroy: template.active
+	oc delete -f template.active
+	rm template.active
+
+artifacts: Dockerfile scripts template.yaml
+
+Dockerfile:
+	cp ../Dockerfile .
+	sed -i '/FROM/c \FROM ${BASE_IMAGE}' Dockerfile
+
+scripts:
+	cp -r ../scripts .
+
+template.yaml:
+	cp ../template.yaml .
+
+clean-artifacts: clean-dockerfile clean-scripts clean-template
+
+clean-dockerfile: Dockerfile
+	rm Dockerfile
+
+clean-scripts: scripts
+	rm -r scripts
+
+clean-template: template.yaml
+	rm template.yaml


### PR DESCRIPTION
The point of this Makefile is to make it easy to generate
an openshift-spark image with a python s2i builder image as
as base, without having to manually maintain a duplicate
docker file. This alternate image has full support for
building pyspark applications which can be passed to
spark-submit, or python applications that invoke
spark-submit, or ...