### PR TITLE
Move "USER root" to earlier in the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM centos:latest
 
 MAINTAINER Matthew Farrellee <matt@cs.wisc.edu>
 
+USER root
 RUN yum install -y epel-release tar java && \
     yum clean all
 
@@ -23,11 +24,9 @@ ENV SPARK_HOME=/opt/spark
 COPY scripts /tmp/scripts
 
 # Custom scripts
-USER root
 RUN [ "bash", "-x", "/tmp/scripts/spark/install" ]
 
 # Cleanup the scripts directory
-USER root
 RUN rm -rf /tmp/scripts
 
 # Switch to the user 185 for OpenShift usage


### PR DESCRIPTION
If the base image is changed to something that does not
end with the user set as root, then the initial layers will
fail.  Setting "USER root" early defends against that.