### PR TITLE
Copy local spark configuration to $SPARK_HOME/conf

### DIFF
--- a/scripts/spark/added/launch.sh
+++ b/scripts/spark/added/launch.sh
@@ -13,19 +13,17 @@ export LD_PRELOAD=libnss_wrapper.so
 
 # If the UPDATE_SPARK_CONF_DIR dir is non-empty,
 # copy the contents to $SPARK_HOME/conf
-if [ -n "$UPDATE_SPARK_CONF_DIR" ]; then
-    ls -1 $UPDATE_SPARK_CONF_DIR &> /dev/null
-    if [ $? -eq 0 ]; then
-        sparkconfs=$(ls -1 $UPDATE_SPARK_CONF_DIR | wc -l)
-        if [ "$sparkconfs" -ne "0" ]; then
-            echo "Copying from $UPDATE_SPARK_CONF_DIR to $SPARK_HOME/conf"
-            ls -1 $UPDATE_SPARK_CONF_DIR
-            cp $UPDATE_SPARK_CONF_DIR/* $SPARK_HOME/conf
-        fi
-    else
-        echo "$UPDATE_SPARK_CONF_DIR does not exist, using default spark config"
+if [ -d "$UPDATE_SPARK_CONF_DIR" ]; then
+    sparkconfs=$(ls -1 $UPDATE_SPARK_CONF_DIR | wc -l)
+    if [ "$sparkconfs" -ne "0" ]; then
+        echo "Copying from $UPDATE_SPARK_CONF_DIR to $SPARK_HOME/conf"
+        ls -1 $UPDATE_SPARK_CONF_DIR
+        cp $UPDATE_SPARK_CONF_DIR/* $SPARK_HOME/conf
     fi
+elif [ -n "$UPDATE_SPARK_CONF_DIR" ]; then
+    echo "Directory $UPDATE_SPARK_CONF_DIR does not exist, using default spark config"
 fi
+
 
 # If SPARK_MASTER_ADDRESS env varaible is not provided, start master,
 # otherwise start worker and connect to SPARK_MASTER_ADDRESS

--- a/scripts/spark/added/launch.sh
+++ b/scripts/spark/added/launch.sh
@@ -11,6 +11,21 @@ export NSS_WRAPPER_GROUP=/etc/group
 
 export LD_PRELOAD=libnss_wrapper.so
 
+# If the /etc/oshinko-spark-configs dir is non-empty,
+# copy the contents to $SPARK_HOME/conf
+USER_SPARK_CONF=/etc/oshinko-spark-configs
+ls -1 $USER_SPARK_CONF &> /dev/null
+if [ $? -eq 0 ]; then
+    sparkconfs=$(ls -1 /etc/oshinko-spark-configs | wc -l)
+    if [ "$sparkconfs" -ne "0" ]; then
+        echo "Copying $USER_SPARK_CONF/* to $SPARK_HOME/conf"
+        ls -1 /etc/oshinko-spark-configs
+        cp $USER_SPARK_CONF/* $SPARK_HOME/conf
+    fi
+else
+    echo "/etc/oshinko-spark-configs does not exist, using default spark config"
+fi
+
 # If SPARK_MASTER_ADDRESS env varaible is not provided, start master,
 # otherwise start worker and connect to SPARK_MASTER_ADDRESS
 if [ -z ${SPARK_MASTER_ADDRESS+_} ]; then

--- a/scripts/spark/added/launch.sh
+++ b/scripts/spark/added/launch.sh
@@ -11,19 +11,20 @@ export NSS_WRAPPER_GROUP=/etc/group
 
 export LD_PRELOAD=libnss_wrapper.so
 
-# If the /etc/oshinko-spark-configs dir is non-empty,
+# If the UPDATE_SPARK_CONF_DIR dir is non-empty,
 # copy the contents to $SPARK_HOME/conf
-USER_SPARK_CONF=/etc/oshinko-spark-configs
-ls -1 $USER_SPARK_CONF &> /dev/null
-if [ $? -eq 0 ]; then
-    sparkconfs=$(ls -1 /etc/oshinko-spark-configs | wc -l)
-    if [ "$sparkconfs" -ne "0" ]; then
-        echo "Copying $USER_SPARK_CONF/* to $SPARK_HOME/conf"
-        ls -1 /etc/oshinko-spark-configs
-        cp $USER_SPARK_CONF/* $SPARK_HOME/conf
+if [ -n "$UPDATE_SPARK_CONF_DIR" ]; then
+    ls -1 $UPDATE_SPARK_CONF_DIR &> /dev/null
+    if [ $? -eq 0 ]; then
+        sparkconfs=$(ls -1 $UPDATE_SPARK_CONF_DIR | wc -l)
+        if [ "$sparkconfs" -ne "0" ]; then
+            echo "Copying from $UPDATE_SPARK_CONF_DIR to $SPARK_HOME/conf"
+            ls -1 $UPDATE_SPARK_CONF_DIR
+            cp $UPDATE_SPARK_CONF_DIR/* $SPARK_HOME/conf
+        fi
+    else
+        echo "$UPDATE_SPARK_CONF_DIR does not exist, using default spark config"
     fi
-else
-    echo "/etc/oshinko-spark-configs does not exist, using default spark config"
 fi
 
 # If SPARK_MASTER_ADDRESS env varaible is not provided, start master,


### PR DESCRIPTION
Rather than have the pod creator set the SPARK_CONF_DIR environment
variable to point to a directory with a modified spark configuration, this change
simply copies the contents of $UPDATE_SPARK_CONF_DIR to $SPARK_HOME/conf
during startup. This gives us a simple overwrite semantic so that only files being
changed must be specified.