### PR TITLE
Removing hardcoded urls for custom build from CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,4 @@ services:
   - docker
 
 script:
-  - make build 
+  - make build

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,4 @@ services:
   - docker
 
 script:
-  - docker build -t openshift-spark --build-arg DISTRO_LOC=https://dist.apache.org/repos/dist/release/spark/spark-2.1.0/spark-2.1.0-bin-hadoop2.7.tgz --build-arg DISTRO_NAME=spark-2.1.0-bin-hadoop2.7 .
+  - make build 

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,4 @@ services:
   - docker
 
 script:
-  - make build
+  - docker build -t openshift-spark --build-arg DISTRO_LOC=https://dist.apache.org/repos/dist/release/spark/spark-2.1.0/spark-2.1.0-bin-hadoop2.7.tgz --build-arg DISTRO_NAME=spark-2.1.0-bin-hadoop2.7 .

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,8 @@ FROM centos:latest
 MAINTAINER Matthew Farrellee <matt@cs.wisc.edu>
 
 USER root
-ARG DISTRO_LOC
-ARG DISTRO_NAME
+ARG DISTRO_LOC=https://dist.apache.org/repos/dist/release/spark/spark-2.1.0/spark-2.1.0-bin-hadoop2.7.tgz
+ARG DISTRO_NAME=spark-2.1.0-bin-hadoop2.7
 
 RUN yum install -y epel-release tar java && \
     yum clean all

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,13 +3,16 @@ FROM centos:latest
 MAINTAINER Matthew Farrellee <matt@cs.wisc.edu>
 
 USER root
+ARG DISTRO_LOC
+ARG DISTRO_NAME
+
 RUN yum install -y epel-release tar java && \
     yum clean all
 
 RUN cd /opt && \
-    curl https://dist.apache.org/repos/dist/release/spark/spark-2.1.0/spark-2.1.0-bin-hadoop2.7.tgz | \
+    curl $DISTRO_LOC  | \
         tar -zx && \
-    ln -s spark-2.1.0-bin-hadoop2.7 spark
+    ln -s $DISTRO_NAME spark
 
 # when the containers are not run w/ uid 0, the uid may not map in
 # /etc/passwd and it may not be possible to modify things like


### PR DESCRIPTION
Using customer build args we can do custom builds 

```bash
docker build -t openshift-spark --build-arg DISTRO_LOC=https://dist.apache.org/repos/dist/release/spark/spark-2.1.0/spark-2.1.0-bin-hadoop2.7.tgz --build-arg DISTRO_NAME=spark-2.1.0-bin-hadoop2.7
```