### PR TITLE
make it easier for users who shell into a container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ RUN rm -rf /tmp/scripts
 # Switch to the user 185 for OpenShift usage
 USER 185
 
-ENTRYPOINT ["/opt/spark/bin/entrypoint"]
+ENTRYPOINT ["/entrypoint"]
 
 # Start the main process
 CMD ["/opt/spark/bin/launch.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,5 +32,7 @@ RUN rm -rf /tmp/scripts
 # Switch to the user 185 for OpenShift usage
 USER 185
 
+ENTRYPOINT ["/opt/spark/bin/entrypoint"]
+
 # Start the main process
 CMD ["/opt/spark/bin/launch.sh"]

--- a/scripts/spark/added/entrypoint
+++ b/scripts/spark/added/entrypoint
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# spark likes to be able to lookup a username for the running UID, if
+# no name is present fake it.
+cat /etc/passwd > /tmp/passwd
+echo "$(id -u):x:$(id -u):$(id -g):dynamic uid:$SPARK_HOME:/bin/false" >> /tmp/passwd
+
+export NSS_WRAPPER_PASSWD=/tmp/passwd
+# NSS_WRAPPER_GROUP must be set for NSS_WRAPPER_PASSWD to be used
+export NSS_WRAPPER_GROUP=/etc/group
+
+export LD_PRELOAD=libnss_wrapper.so
+
+exec "$@"

--- a/scripts/spark/added/launch.sh
+++ b/scripts/spark/added/launch.sh
@@ -1,16 +1,5 @@
 #!/bin/bash
 
-# spark likes to be able to lookup a username for the running UID, if
-# no name is present fake it.
-cat /etc/passwd > /tmp/passwd
-echo "$(id -u):x:$(id -u):$(id -g):dynamic uid:$SPARK_HOME:/bin/false" >> /tmp/passwd
-
-export NSS_WRAPPER_PASSWD=/tmp/passwd
-# NSS_WRAPPER_GROUP must be set for NSS_WRAPPER_PASSWD to be used
-export NSS_WRAPPER_GROUP=/etc/group
-
-export LD_PRELOAD=libnss_wrapper.so
-
 # If the UPDATE_SPARK_CONF_DIR dir is non-empty,
 # copy the contents to $SPARK_HOME/conf
 if [ -d "$UPDATE_SPARK_CONF_DIR" ]; then

--- a/scripts/spark/install
+++ b/scripts/spark/install
@@ -5,6 +5,9 @@ set -e
 SCRIPT_DIR=$(dirname $0)
 ADDED_DIR=${SCRIPT_DIR}/added
 
+mv $ADDED_DIR/entrypoint $SPARK_HOME/bin/
+chmod +x $SPARK_HOME/bin/entrypoint
+
 mv $ADDED_DIR/launch.sh $SPARK_HOME/bin/
 chmod +x $SPARK_HOME/bin/launch.sh
 

--- a/scripts/spark/install
+++ b/scripts/spark/install
@@ -5,8 +5,8 @@ set -e
 SCRIPT_DIR=$(dirname $0)
 ADDED_DIR=${SCRIPT_DIR}/added
 
-mv $ADDED_DIR/entrypoint $SPARK_HOME/bin/
-chmod +x $SPARK_HOME/bin/entrypoint
+mv $ADDED_DIR/entrypoint /
+chmod +x /entrypoint
 
 mv $ADDED_DIR/launch.sh $SPARK_HOME/bin/
 chmod +x $SPARK_HOME/bin/launch.sh


### PR DESCRIPTION
user still needs to run /entrypoint, but that's simpler than
cut&pasting nss setup commands