### PR TITLE
Remove extraneous tabs from config file

### DIFF
--- a/scripts/spark/added/spark-defaults.conf
+++ b/scripts/spark/added/spark-defaults.conf
@@ -25,5 +25,5 @@
 # spark.serializer                 org.apache.spark.serializer.KryoSerializer
 # spark.driver.memory              5g
 # spark.executor.extraJavaOptions  -XX:+PrintGCDetails -Dkey=value -Dnumbers="one two three"
-spark.ui.reverseProxy		   true
+spark.ui.reverseProxy              true
 spark.ui.reverseProxyUrl           /


### PR DESCRIPTION
Tabs will mess up formatting for some things,
notably storage of text in configmaps