### PR TITLE
Add signal handlers for launch.sh

### DIFF
--- a/scripts/spark/added/launch.sh
+++ b/scripts/spark/added/launch.sh
@@ -9,6 +9,22 @@ function check_reverse_proxy {
     fi
 }
 
+function handle_term {
+    echo Received a termination signal
+    # If we've saved a PID for a subprocess, kill that first before
+    # trying to delete the cluster
+    if ! [ -z ${PID+x} ]; then
+        echo "Stopping subprocess $PID"
+        kill -TERM $PID
+        wait $PID
+        echo "Subprocess stopped"
+    fi
+    exit 0
+}
+
+
+trap handle_term TERM INT
+
 # If the UPDATE_SPARK_CONF_DIR dir is non-empty,
 # copy the contents to $SPARK_HOME/conf
 if [ -d "$UPDATE_SPARK_CONF_DIR" ]; then

--- a/scripts/spark/added/launch.sh
+++ b/scripts/spark/added/launch.sh
@@ -13,7 +13,7 @@ function handle_term {
     echo Received a termination signal
     # If we've saved a PID for a subprocess, kill that first before
     # trying to delete the cluster
-    if ! [ -z ${PID+x} ]; then
+    if [ -n "$PID" ]; then
         echo "Stopping subprocess $PID"
         kill -TERM $PID
         wait $PID
@@ -53,7 +53,7 @@ fi
 
 if [ -z ${SPARK_MASTER_ADDRESS+_} ]; then
     echo "Starting master$metrics"
-    exec $SPARK_HOME/bin/spark-class$JAVA_AGENT org.apache.spark.deploy.master.Master
+    $SPARK_HOME/bin/spark-class$JAVA_AGENT org.apache.spark.deploy.master.Master &
 else
     echo "Starting worker$metrics, will connect to: $SPARK_MASTER_ADDRESS"
     while true; do
@@ -64,5 +64,7 @@ else
         fi
         sleep 1
     done
-    exec $SPARK_HOME/bin/spark-class$JAVA_AGENT org.apache.spark.deploy.worker.Worker $SPARK_MASTER_ADDRESS
+    $SPARK_HOME/bin/spark-class$JAVA_AGENT org.apache.spark.deploy.worker.Worker $SPARK_MASTER_ADDRESS &
 fi
+PID=$!
+wait $PID

--- a/scripts/spark/added/launch.sh
+++ b/scripts/spark/added/launch.sh
@@ -11,11 +11,28 @@ function check_reverse_proxy {
 
 function handle_term {
     echo Received a termination signal
+
     # If we've saved a PID for a subprocess, kill that first before
     # trying to delete the cluster
+    local cnt
+    local killed=1
     if [ -n "$PID" ]; then
         echo "Stopping subprocess $PID"
         kill -TERM $PID
+        for cnt in {1..10}
+        do
+            kill -0 $PID >/dev/null 2>&1
+            if [ "$?" -ne 0 ]; then
+                killed=0
+                break
+            else
+                sleep 1
+            fi
+        done
+        if [ "$killed" -ne 0 ]; then
+            echo Process is still running 10 seconds after TERM, sending KILL
+            kill -9 $PID
+        fi
         wait $PID
         echo "Subprocess stopped"
     fi


### PR DESCRIPTION
In order to terminate spark pods quickly, we need
signal handlers for SIGTERM and SIGINT. Additionally,
we should run the spark processes in the background and
use "wait", recording the PID so that we can issue an
immediate kill to spark.

This is the same strategy we use in the driver.