### PR TITLE
Do not configure cluster for reverse proxy by default.

### DIFF
--- a/scripts/spark/added/launch.sh
+++ b/scripts/spark/added/launch.sh
@@ -22,7 +22,7 @@ elif [ -n "$UPDATE_SPARK_CONF_DIR" ]; then
     echo "Directory $UPDATE_SPARK_CONF_DIR does not exist, using default spark config"
 fi
 
-check_reverse_proxy
+#check_reverse_proxy
 
 # If SPARK_MASTER_ADDRESS env varaible is not provided, start master,
 # otherwise start worker and connect to SPARK_MASTER_ADDRESS

--- a/scripts/spark/added/spark-defaults.conf
+++ b/scripts/spark/added/spark-defaults.conf
@@ -25,5 +25,5 @@
 # spark.serializer                 org.apache.spark.serializer.KryoSerializer
 # spark.driver.memory              5g
 # spark.executor.extraJavaOptions  -XX:+PrintGCDetails -Dkey=value -Dnumbers="one two three"
-spark.ui.reverseProxy              true
-spark.ui.reverseProxyUrl           /
+#spark.ui.reverseProxy              true
+#spark.ui.reverseProxyUrl           /


### PR DESCRIPTION
Due to the issue noted in jira SPARK-20853, this PR
removes the logic that enables reverse proxy by default
in the openshift-spark image.