### PR TITLE
Thinner docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,8 +19,9 @@ COPY metrics /tmp/spark
 # when the containers are not run w/ uid 0, the uid may not map in
 # /etc/passwd and it may not be possible to modify things like
 # /etc/hosts. nss_wrapper provides an LD_PRELOAD way to modify passwd
-# and hosts.
-RUN yum install -y epel-release tar java nss_wrapper numpy && \
+# and hosts. nss_wrapper package needs to be installed in its own step
+RUN yum install -y epel-release tar java numpy && \
+    yum install -y nss_wrapper && \
     cd /opt && \
     curl -O --progress-bar $DISTRO_LOC && \
     echo "9d1188efbbc92ba6aa0b834ea684d00fa7b63e39 `ls spark-*`" | sha1sum -c - && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,37 +3,34 @@ FROM centos:latest
 MAINTAINER Matthew Farrellee <matt@cs.wisc.edu>
 
 USER root
+
+# when changing the version, don't forget also to change the sha1 checksum
 ARG DISTRO_LOC=https://archive.apache.org/dist/spark/spark-2.1.0/spark-2.1.0-bin-hadoop2.7.tgz
-ARG DISTRO_NAME=spark-2.1.0-bin-hadoop2.7
 
-RUN yum install -y epel-release tar java && \
-    yum clean all
-
-RUN cd /opt && \
-    curl $DISTRO_LOC  | \
-        tar -zx && \
-    ln -s $DISTRO_NAME spark
-
-# when the containers are not run w/ uid 0, the uid may not map in
-# /etc/passwd and it may not be possible to modify things like
-# /etc/hosts. nss_wrapper provides an LD_PRELOAD way to modify passwd
-# and hosts.
-RUN yum install -y nss_wrapper numpy && yum clean all
-
-ENV PATH=$PATH:/opt/spark/bin
-ENV SPARK_HOME=/opt/spark
+ENV PATH="$PATH:/opt/spark/bin" \
+    SPARK_HOME="/opt/spark"
 
 # Add scripts used to configure the image
 COPY scripts /tmp/scripts
 
 # Adding jmx by default
-COPY metrics /opt/spark
+COPY metrics /tmp/spark
 
-# Custom scripts
-RUN [ "bash", "-x", "/tmp/scripts/spark/install" ]
-
-# Cleanup the scripts directory
-RUN rm -rf /tmp/scripts
+# when the containers are not run w/ uid 0, the uid may not map in
+# /etc/passwd and it may not be possible to modify things like
+# /etc/hosts. nss_wrapper provides an LD_PRELOAD way to modify passwd
+# and hosts.
+RUN yum install -y epel-release tar java nss_wrapper numpy && \
+    cd /opt && \
+    curl -O --progress-bar $DISTRO_LOC && \
+    echo "9d1188efbbc92ba6aa0b834ea684d00fa7b63e39 `ls spark-*`" | sha1sum -c - && \
+    tar -zxf spark-* && \
+    rm -rf spark-*.tgz && \
+    ln -s spark-* spark && \
+    mv /tmp/spark/* spark/ && \
+    bash -x /tmp/scripts/spark/install && \
+    rm -rf /tmp/scripts && \
+    yum clean all
 
 # Switch to the user 185 for OpenShift usage
 USER 185

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 [![Build status](https://travis-ci.org/radanalyticsio/openshift-spark.svg?branch=master)](https://travis-ci.org/radanalyticsio/openshift-spark)
 [![Docker build](https://img.shields.io/docker/automated/radanalyticsio/openshift-spark.svg)](https://hub.docker.com/r/radanalyticsio/openshift-spark)
+[![Layers info](https://images.microbadger.com/badges/image/radanalyticsio/openshift-spark.svg)](https://microbadger.com/images/radanalyticsio/openshift-spark)
 
 # Apache Spark images for OpenShift
 


### PR DESCRIPTION
This PR reduces the size of the image from 927 MB to ~~626~~ 683 MB.
Because other our images are based on this one, it'll also reduce their size.

update:
I've checked the modified image with the `https://radanalytics.io/resources.yaml` template and it works well.

update2:
..and the var notebook also worked well

@tmckayus could you please take a look?