### PR TITLE
Run tini as pid 1 so that catches and forwards signals

### DIFF
--- a/scripts/spark/added/entrypoint
+++ b/scripts/spark/added/entrypoint
@@ -15,4 +15,4 @@ if [ -z "$uidentry" ] ; then
 fi
 
 # Execute the container CMD under tini for better hygiene
-tini -s -- "$@"
+exec tini -s -- "$@"


### PR DESCRIPTION
The launch.sh script does a small amount of work and
then execs the spark process with no long waits. Therefore,
as long as tini forwards signals, either bash or spark
should receive a SIGTERM and shut down quickly.
  