### PR TITLE
Restore config files to /opt/spark/conf

### DIFF
--- a/modules/spark/install
+++ b/modules/spark/install
@@ -24,6 +24,10 @@ chmod +x /entrypoint
 mv $ADDED_DIR/launch.sh $SPARK_HOME/bin/
 chmod +x $SPARK_HOME/bin/launch.sh
 
+mv $ADDED_DIR/*.properties $SPARK_HOME/conf/
+mv $ADDED_DIR/*.conf $SPARK_HOME/conf/
+mv $ADDED_DIR/*.yaml $SPARK_HOME/conf/
+
 # SPARK_WORKER_DIR defaults to SPARK_HOME/work and is created on
 # Worker startup if it does not exist. instead of making SPARK_HOME
  # world writable, create SPARK_HOME/work.

--- a/openshift-spark-build/modules/spark/install
+++ b/openshift-spark-build/modules/spark/install
@@ -24,6 +24,10 @@ chmod +x /entrypoint
 mv $ADDED_DIR/launch.sh $SPARK_HOME/bin/
 chmod +x $SPARK_HOME/bin/launch.sh
 
+mv $ADDED_DIR/*.properties $SPARK_HOME/conf/
+mv $ADDED_DIR/*.conf $SPARK_HOME/conf/
+mv $ADDED_DIR/*.yaml $SPARK_HOME/conf/
+
 # SPARK_WORKER_DIR defaults to SPARK_HOME/work and is created on
 # Worker startup if it does not exist. instead of making SPARK_HOME
  # world writable, create SPARK_HOME/work.


### PR DESCRIPTION
Some config files in the final image were dropped
in the move to concreate