### PR TITLE
Change spark release references

### DIFF
--- a/image.yaml
+++ b/image.yaml
@@ -24,7 +24,7 @@ packages:
           - numpy
           - wget
 artifacts:
-    - url: https://dist.apache.org/repos/dist/release/spark/spark-2.2.1/spark-2.2.1-bin-hadoop2.7.tgz
+    - url: https://archive.apache.org/dist/spark/spark-2.2.1/spark-2.2.1-bin-hadoop2.7.tgz
       md5: c0081f6076070f0a6c6a607c71ac7e95
 run:
       user: 185

--- a/modules/spark/check_for_download
+++ b/modules/spark/check_for_download
@@ -3,5 +3,5 @@ echo "checking length of file $1"
 if ! [ -s "$1" ]; then
     filename=$(basename $1)
     version=$(echo $filename | cut -d '-' -f2)
-    wget https://dist.apache.org/repos/dist/release/spark/spark-$version/spark-$version-bin-hadoop2.7.tgz -O $1
+    wget https://archive.apache.org/dist/spark/spark-$version/spark-$version-bin-hadoop2.7.tgz -O $1
 fi

--- a/modules/spark/install
+++ b/modules/spark/install
@@ -3,8 +3,6 @@
  SCRIPT_DIR=$(dirname $0)
  ADDED_DIR=${SCRIPT_DIR}/added
 
-DISTRO_NAME=spark-2.2.1-bin-hadoop2.7
-
 # If there is a zero-length spark tarball, find the verison in the
 # name and download from Apache
 fullname=$(find $ARTIFACTS_DIR -name spark-[0-9.]*\.tgz)
@@ -13,9 +11,9 @@ fullname=$(find $ARTIFACTS_DIR -name spark-[0-9.]*\.tgz)
 # unpack the spark tools
 {
     cd /tmp/artifacts
-    tar xzf "$DISTRO_NAME.tgz"
-    mv "$DISTRO_NAME" /opt
-    ln -s "/opt/$DISTRO_NAME" "/opt/spark"
+    tar xzf spark-*-bin-hadoop*.tgz
+    mv spark-*-bin-hadoop*/ /opt
+    ln -s /opt/spark-*-bin-hadoop* "/opt/spark"
 }
 
 mv $ADDED_DIR/entrypoint /

--- a/openshift-spark-build/Dockerfile
+++ b/openshift-spark-build/Dockerfile
@@ -30,7 +30,8 @@ LABEL name="$JBOSS_IMAGE_NAME" \
       architecture="x86_64" \
       com.redhat.component="testing-openshift-spark-docker" \
       maintainer="Chad Roberts <croberts@redhat.com>" \
-      sparkversion="2.2.1"
+      sparkversion="2.2.1" \
+      org.concrt.version="1.4.0"
 
 
 USER root

--- a/openshift-spark-build/modules/spark/check_for_download
+++ b/openshift-spark-build/modules/spark/check_for_download
@@ -3,5 +3,5 @@ echo "checking length of file $1"
 if ! [ -s "$1" ]; then
     filename=$(basename $1)
     version=$(echo $filename | cut -d '-' -f2)
-    wget https://dist.apache.org/repos/dist/release/spark/spark-$version/spark-$version-bin-hadoop2.7.tgz -O $1
+    wget https://archive.apache.org/dist/spark/spark-$version/spark-$version-bin-hadoop2.7.tgz -O $1
 fi

--- a/openshift-spark-build/modules/spark/install
+++ b/openshift-spark-build/modules/spark/install
@@ -3,8 +3,6 @@
  SCRIPT_DIR=$(dirname $0)
  ADDED_DIR=${SCRIPT_DIR}/added
 
-DISTRO_NAME=spark-2.2.1-bin-hadoop2.7
-
 # If there is a zero-length spark tarball, find the verison in the
 # name and download from Apache
 fullname=$(find $ARTIFACTS_DIR -name spark-[0-9.]*\.tgz)
@@ -13,9 +11,9 @@ fullname=$(find $ARTIFACTS_DIR -name spark-[0-9.]*\.tgz)
 # unpack the spark tools
 {
     cd /tmp/artifacts
-    tar xzf "$DISTRO_NAME.tgz"
-    mv "$DISTRO_NAME" /opt
-    ln -s "/opt/$DISTRO_NAME" "/opt/spark"
+    tar xzf spark-*-bin-hadoop*.tgz
+    mv spark-*-bin-hadoop*/ /opt
+    ln -s /opt/spark-*-bin-hadoop* "/opt/spark"
 }
 
 mv $ADDED_DIR/entrypoint /


### PR DESCRIPTION
* Pull spark from archives endpoint instead of release endpoint
  This prevents us from losing a link if we lag behind apache releases.

* Use wildcards in spark install.
  This is in prep for a release script to update spark version.
  If we use wildcards, it's one less place we have to update.