### PR TITLE
Add utility scripts to simplify changes

### DIFF
--- a/change-yaml.sh
+++ b/change-yaml.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+
+function usage() {
+    echo
+
+    echo "Changes the image.*.yaml file and adds it to the current commit (git add)"
+    echo
+    echo "Usage: change-yaml.sh [options] SPARK_VERSION"
+    echo
+    echo "required arguments"
+    echo
+    echo "  SPARK_VERSION      The spark version number, like 2.2.1"
+    echo
+    echo "optional arguments:"
+    echo
+    echo "  -h                  Show this message"
+}
+
+# Set the hadoop version
+HVER=2.7
+
+while getopts h opt; do
+    case $opt in
+        h)
+            usage
+            exit 0
+            ;;
+        \?)
+            echo "Invalid option: -$OPTARG" >&2
+            exit 1
+            ;;
+    esac
+done
+
+shift "$((OPTIND-1))"
+
+if [ "$#" -lt 1 ]; then
+    echo No spark version specified
+    usage
+    exit 1
+fi
+
+SPARK=$1
+
+# Extract the current spark version from the image.yaml file
+# Works by parsing the line following "name: sparkversion"
+VER=$(sed -n '\@name: sparkversion@!b;n;p' image.yaml  | tr -d '[:space:]' | cut -d':' -f2)
+if [ "$VER" == "$SPARK" ]; then
+    echo "Nothing to do, spark version in image.yaml is already $SPARK"
+    exit 0
+fi
+
+# Change spark distro and download urls
+if [ ! -z ${SPARK+x} ]; then
+
+    wget https://archive.apache.org/dist/spark/spark-${SPARK}/spark-${SPARK}-bin-hadoop${HVER}.tgz.md5 -O /tmp/spark-${SPARK}-bin-hadoop${HVER}.tgz.md5
+    if [ "$?" -eq 0 ]; then
+
+        sum=$(cat /tmp/spark-${SPARK}-bin-hadoop2.7.tgz.md5 | cut -d':' -f 2 | tr -d '[:space:]' | tr '[:upper:]' '[:lower:]')
+
+	# Fix the url references
+	sed -i "s@https://archive.apache.org/dist/spark/spark-.*/spark-.*-bin-@https://archive.apache.org/dist/spark/spark-${SPARK}/spark-${SPARK}-bin-@" image.yaml
+
+	# Fix the md5 sum references on the line following the url
+        sed -i '\@url: https://archive.apache.org/dist/spark/@!b;n;s/md5.*/md5: '$sum'/' image.yaml
+
+	# Fix the spark version label
+	sed -i '\@name: sparkversion@!b;n;s/value.*/value: '$SPARK'/' image.yaml
+
+        # Fix the concreate version value
+        V=$(echo $SPARK | cut -d'.' -f1,2)
+        sed -i 's@^version:.*-latest$@version: '$V'-latest@' image.yaml
+
+    else
+        echo "Failed to get the md5 sum for the specified spark version, the version $SPARK may not be a real version"
+        exit 1
+    fi
+fi
+
+git add image.yaml

--- a/make-build-dir.sh
+++ b/make-build-dir.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# Regenerate the build directory based on image.*.yaml
+make clean-context
+make context
+make zero-tarballs
+
+# Add any changes for a commit
+git add openshift-spark-build

--- a/tag.sh
+++ b/tag.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+function usage() {
+    echo
+    echo "Creates a new tag for the current repo based on the spark version specified in image.yaml"
+    echo "and the latest tag."
+    echo
+    echo "Usage: tag.sh"
+    echo
+    echo "optional arguments:"
+    echo
+    echo "  -h                  Show this message"
+}
+
+while getopts h opt; do
+    case $opt in
+        h)
+            usage
+            exit 0
+            ;;
+        \?)
+            echo "Invalid option: -$OPTARG" >&2
+            exit 1
+            ;;
+    esac
+done
+
+# Extract the current spark version from the image.yaml file
+# Works by parsing the line following "name: sparkversion"
+VER=$(sed -n '\@name: sparkversion@!b;n;p' image.yaml  | tr -d '[:space:]' | cut -d':' -f2)
+
+echo Version from image.yaml is $VER
+
+TAG=$(git describe --abbrev=0 --tags)
+
+PREFIX=$(echo $TAG | cut -d'-' -f1)
+BUILD=$(echo $TAG | cut -d'-' -f2)
+
+# If we already have tags for Major.Minor version, just increment the build number
+# If we don't already have tags for Major.Minor, start with build 1
+newbranch=0
+if [ "$PREFIX" == "$VER" ]; then
+    TAG="$PREFIX-$((BUILD+1))"
+else
+    TAG="$VER-1"
+    newbranch=1
+fi
+
+echo "Adding tag $TAG"
+git tag "$TAG"
+if [ "$?" -eq 0 ]; then
+    echo Tag "$TAG" added, don\'t forget to push to upstream
+    MAJORMINOR=$(echo $VER | cut -d'.' -f1,2)
+    if [ "$newbranch" == 0 ]; then
+	echo "Also, don't forget to rebase branch $MAJORMINOR on master if necessary"
+    else
+	echo "Also, looks like a new version of spark. Don't forget to create a $MAJORMINOR branch from master"
+    fi
+else
+    echo Addition of tag "$TAG" failed
+fi


### PR DESCRIPTION
This change provides the following two scripts. When updating
some aspect of an image.yaml, both will be used. When only
modifying some image content under modules/, only the second
will be used.

* change-yaml.sh

  This is for easily altering dependencies in the image.yaml file.
  It modifies the well-known url based on the dependency version speicified
  and calculates a new md5sum for each artifact.

* make-build-dir.sh

  This is for regenerating the build dir based on the current
  image.yaml file and repo content. It adds any resulting
  changes to the commit