### PR TITLE
Add env vars to allow testing non-local spark image

### DIFF
--- a/test/cmd/config-changes.sh
+++ b/test/cmd/config-changes.sh
@@ -2,13 +2,18 @@
 source "$(dirname "${BASH_SOURCE}")/../../hack/lib/init.sh"
 trap os::test::junit::reconcile_output EXIT
 
+source "$(dirname "${BASH_SOURCE}")/../common.sh"
+
 RESOURCE_DIR="$(dirname "${BASH_SOURCE}")/../resources"
 
 os::test::junit::declare_suite_start "cmd/create"
 
+# Handles registries, etc, and sets SPARK_IMAGE to the right value
+make_image
+
 os::cmd::expect_success 'oc create configmap test-config --from-file=$RESOURCE_DIR/config'
 
-os::cmd::expect_success 'oc new-app --file=$RESOURCE_DIR/test-template.yaml -p MASTER_NAME=master -p WORKER_NAME=worker -p SPARK_IMAGE="$OPENSHIFT_SPARK_TEST_IMAGE"'
+os::cmd::expect_success 'oc new-app --file=$RESOURCE_DIR/test-template.yaml -p MASTER_NAME=master -p WORKER_NAME=worker -p SPARK_IMAGE="$SPARK_IMAGE"'
 
 os::cmd::try_until_text 'oc logs dc/master' 'Copying from /etc/config to /opt/spark/conf'
 

--- a/test/cmd/deploy.sh
+++ b/test/cmd/deploy.sh
@@ -4,11 +4,16 @@ trap os::test::junit::reconcile_output EXIT
 
 os::test::junit::declare_suite_start "cmd/create"
 
+source "$(dirname "${BASH_SOURCE}")/../common.sh"
+
 RESOURCE_DIR="$(dirname "${BASH_SOURCE}")/../resources"
+
+# Handles registries, etc, and sets SPARK_IMAGE to the right value
+make_image
 
 os::cmd::expect_success 'oc create configmap test-config --from-file=$RESOURCE_DIR/config'
 
-os::cmd::expect_success 'oc new-app --file=$RESOURCE_DIR/test-template.yaml -p MASTER_NAME=master -p WORKER_NAME=worker -p SPARK_IMAGE="$OPENSHIFT_SPARK_TEST_IMAGE"'
+os::cmd::expect_success 'oc new-app --file=$RESOURCE_DIR/test-template.yaml -p MASTER_NAME=master -p WORKER_NAME=worker -p SPARK_IMAGE="$SPARK_IMAGE"'
 
 #check pods have been created
 os::cmd::try_until_text 'oc get pods' 'worker'

--- a/test/cmd/deploy_jolokia.sh
+++ b/test/cmd/deploy_jolokia.sh
@@ -2,13 +2,18 @@
 source "$(dirname "${BASH_SOURCE}")/../../hack/lib/init.sh"
 trap os::test::junit::reconcile_output EXIT
 
+source "$(dirname "${BASH_SOURCE}")/../common.sh"
+
 os::test::junit::declare_suite_start "cmd/create"
 
 RESOURCE_DIR="$(dirname "${BASH_SOURCE}")/../resources"
 
+# Handles registries, etc, and sets SPARK_IMAGE to the right value
+make_image
+
 os::cmd::expect_success 'oc create configmap test-config --from-file=$RESOURCE_DIR/config'
 
-os::cmd::expect_success 'oc new-app --file=$RESOURCE_DIR/test-spark-metrics-template.yaml -p MASTER_NAME=master -p WORKER_NAME=worker -p SPARK_IMAGE="$OPENSHIFT_SPARK_TEST_IMAGE" -p SPARK_METRICS_ON=jolokia'
+os::cmd::expect_success 'oc new-app --file=$RESOURCE_DIR/test-spark-metrics-template.yaml -p MASTER_NAME=master -p WORKER_NAME=worker -p SPARK_IMAGE="$SPARK_IMAGE" -p SPARK_METRICS_ON=jolokia'
 
 # check the master has started the metrics
 os::cmd::try_until_text 'oc logs dc/master' 'Starting master with jolokia metrics enabled'

--- a/test/cmd/deploy_prometheus.sh
+++ b/test/cmd/deploy_prometheus.sh
@@ -2,13 +2,18 @@
 source "$(dirname "${BASH_SOURCE}")/../../hack/lib/init.sh"
 trap os::test::junit::reconcile_output EXIT
 
+source "$(dirname "${BASH_SOURCE}")/../common.sh"
+
 os::test::junit::declare_suite_start "cmd/create"
 
 RESOURCE_DIR="$(dirname "${BASH_SOURCE}")/../resources"
 
+# Handles registries, etc, and sets SPARK_IMAGE to the right value
+make_image
+
 os::cmd::expect_success 'oc create configmap test-config --from-file=$RESOURCE_DIR/config'
 
-os::cmd::expect_success 'oc new-app --file=$RESOURCE_DIR/test-spark-metrics-template.yaml -p MASTER_NAME=master -p WORKER_NAME=worker -p SPARK_IMAGE="$OPENSHIFT_SPARK_TEST_IMAGE" -p SPARK_METRICS_ON=prometheus'
+os::cmd::expect_success 'oc new-app --file=$RESOURCE_DIR/test-spark-metrics-template.yaml -p MASTER_NAME=master -p WORKER_NAME=worker -p SPARK_IMAGE="$SPARK_IMAGE" -p SPARK_METRICS_ON=prometheus'
 
 # check the master has started the metrics
 os::cmd::try_until_text 'oc logs dc/master' 'Starting master with prometheus metrics enabled'

--- a/test/common.sh
+++ b/test/common.sh
@@ -1,0 +1,94 @@
+#!/bin/bash
+
+SPARK_TEST_IMAGE=${SPARK_TEST_IMAGE:-}
+
+SPARK_TEST_LOCAL_IMAGE=${SPARK_TEST_LOCAL_IMAGE:-true}
+
+# This is all for dealing with registries. External registry requires creds other than the current login
+SPARK_TEST_INTEGRATED_REGISTRY=${SPARK_TEST_INTEGRATED_REGISTRY:-}
+SPARK_TEST_EXTERNAL_REGISTRY=${SPARK_TEST_EXTERNAL_REGISTRY:-}
+SPARK_TEST_EXTERNAL_USER=${SPARK_TEST_EXTERNAL_USER:-}
+SPARK_TEST_EXTERNAL_PASSWORD=${SPARK_TEST_EXTERNAL_PASSWORD:-}
+
+if [ -z "$SPARK_TEST_IMAGE" ]; then
+    if [ "$SPARK_TEST_LOCAL_IMAGE" == true ]; then
+        SPARK_TEST_IMAGE=spark-testimage:latest
+    else
+        SPARK_TEST_IMAGE=docker.io/radanalyticsio/openshift-spark:latest
+    fi
+fi
+
+function print_test_env {
+    echo Using image $SPARK_TEST_IMAGE
+
+    if [ "$SPARK_TEST_LOCAL_IMAGE" != true ]; then
+	echo SPARK_TEST_LOCAL_IMAGE = $SPARK_TEST_LOCAL_IMAGE, spark image is external, ignoring registry env vars
+    elif [ -n "$SPARK_TEST_EXTERNAL_REGISTRY" ]; then
+        echo Using external registry $SPARK_TEST_EXTERNAL_REGISTRY
+        if [ -z "$SPARK_TEST_EXTERNAL_USER" ]; then
+            echo "Error: SPARK_TEST_EXTERNAL_USER not set!"
+	    exit 1
+        else
+	    echo Using external registry user $SPARK_TEST_EXTERNAL_USER
+        fi
+        if [ -z "$SPARK_TEST_EXTERNAL_PASSWORD" ]; then
+            echo "SPARK_TEST_EXTERNAL_PASSWORD not set, assuming current docker login"
+        else
+            echo External registry password set
+        fi
+    elif [ -n "$SPARK_TEST_INTEGRATED_REGISTRY" ]; then
+        echo Using integrated registry $SPARK_TEST_INTEGRATED_REGISTRY
+    else
+        echo Not using external or integrated registry
+    fi
+}
+print_test_env
+
+function make_image {
+    # The ip address of an internal/external registry may be set to support running against
+    # an openshift that is not "oc cluster up" when using images that have been built locally.
+    # In the case of "oc cluster up", the docker on the host is available from openshift so
+    # no special pushes of images have to be done.
+    # In the case of a "normal" openshift cluster, a local image we'll use for build has to be
+    # available from the designated registry.
+    # If we're using an image already in an external registry, openshift can pull it from
+    # there and we don't have to do anything.
+    local user=
+    local password=
+    local pushproj=
+    local pushimage=
+    local registry=
+    if [ "$SPARK_TEST_LOCAL_IMAGE" == true ]; then
+	if [ -n  "$SPARK_TEST_EXTERNAL_REGISTRY" ]; then
+	    user=$SPARK_TEST_EXTERNAL_USER
+	    password=$SPARK_TEST_EXTERNAL_PASSWORD
+	    pushproj=$user
+	    pushimage=scratch-openshift-spark
+	    registry=$SPARK_TEST_EXTERNAL_REGISTRY
+	elif [ -n "$SPARK_TEST_INTEGRATED_REGISTRY" ]; then
+	    user=$(oc whoami)
+	    password=$(oc whoami -t)
+	    pushproj=$PROJECT
+	    pushimage=oshinko-webui
+	    registry=$SPARK_TEST_INTEGRATED_REGISTRY
+	fi
+    fi
+    if [ -n "$registry" ]; then
+	set +e
+	docker login --help | grep email &> /dev/null
+	res=$?
+	set -e
+	if [ -n "$password" ] && [ -n "$user" ]; then
+	    if [ "$res" -eq 0 ]; then
+		docker login -u ${user} -e jack@jack.com -p ${password} ${registry}
+	    else
+		docker login -u ${user} -p ${password} ${registry}
+	    fi
+	fi
+	docker tag ${SPARK_TEST_IMAGE} ${registry}/${pushproj}/${pushimage}
+	docker push ${registry}/${pushproj}/${pushimage}
+	SPARK_IMAGE=${registry}/${pushproj}/${pushimage}
+    else
+	SPARK_IMAGE=$SPARK_TEST_IMAGE
+    fi
+}

--- a/test/run.sh
+++ b/test/run.sh
@@ -6,9 +6,6 @@ source "$(dirname "${BASH_SOURCE}")/../hack/lib/init.sh"
 
 os::util::environment::setup_time_vars
 
-OPENSHIFT_SPARK_TEST_IMAGE=${OPENSHIFT_SPARK_TEST_IMAGE:-spark-testimage}
-export OPENSHIFT_SPARK_TEST_IMAGE
-
 function cleanup()
 {
     out=$?


### PR DESCRIPTION
This changes adds settings so that a locally build spark
image can be pushed to an integrated or external registry,
or an existing image can be used from an external registry.