### PR TITLE
add application source to metrics.properties

### DIFF
--- a/modules/spark/added/metrics.properties
+++ b/modules/spark/added/metrics.properties
@@ -3,3 +3,4 @@ master.source.jvm.class=org.apache.spark.metrics.source.JvmSource
 worker.source.jvm.class=org.apache.spark.metrics.source.JvmSource
 driver.source.jvm.class=org.apache.spark.metrics.source.JvmSource
 executor.source.jvm.class=org.apache.spark.metrics.source.JvmSource
+application.source.jvm.class=org.apache.spark.metrics.source.JvmSource

--- a/openshift-spark-build/modules/spark/added/metrics.properties
+++ b/openshift-spark-build/modules/spark/added/metrics.properties
@@ -3,3 +3,4 @@ master.source.jvm.class=org.apache.spark.metrics.source.JvmSource
 worker.source.jvm.class=org.apache.spark.metrics.source.JvmSource
 driver.source.jvm.class=org.apache.spark.metrics.source.JvmSource
 executor.source.jvm.class=org.apache.spark.metrics.source.JvmSource
+application.source.jvm.class=org.apache.spark.metrics.source.JvmSource


### PR DESCRIPTION
Add  "application.source.jvm.class=org.apache.spark.metrics.source.JvmSource"
to metrics.properties sources
causing collection of detailed per job metrics 
