### PR TITLE
For master and worker nodes to infer the JVM memory settings based on cgroups

### DIFF
--- a/modules/common/added/scripts/launch.sh
+++ b/modules/common/added/scripts/launch.sh
@@ -35,11 +35,19 @@ else
     metrics=" with jolokia metrics enabled (deprecated, set SPARK_METRICS_ON to 'prometheus')"
 fi
 
+if [ ${USE_CGROUP_MEMORY} == "true" ]; then
+    SPARK_JAVA_OPTS=${SPARK_JAVA_OPTS:-"-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -XX:MaxRAMFraction=2 -XshowSettings:vm"}
+    START_CMD="java $JAVA_AGENT $SPARK_JAVA_OPTS -cp /opt/spark/conf/:/opt/spark/jars/*"
+else
+    START_CMD="$SPARK_HOME/bin/spark-class$JAVA_AGENT"
+fi
+
 if [ -z ${SPARK_MASTER_ADDRESS+_} ]; then
     echo "Starting master$metrics"
-    exec $SPARK_HOME/bin/spark-class$JAVA_AGENT org.apache.spark.deploy.master.Master
+    START_CLASS="org.apache.spark.deploy.master.Master $SPARK_MASTER_ADDRESS"
 else
     echo "Starting worker$metrics, will connect to: $SPARK_MASTER_ADDRESS"
+    START_CLASS="org.apache.spark.deploy.worker.Worker"
     while true; do
         echo "Waiting for spark master to be available ..."
         curl --connect-timeout 1 -s -X GET $SPARK_MASTER_UI_ADDRESS > /dev/null
@@ -48,5 +56,6 @@ else
         fi
         sleep 1
     done
-    exec $SPARK_HOME/bin/spark-class$JAVA_AGENT org.apache.spark.deploy.worker.Worker $SPARK_MASTER_ADDRESS
 fi
+
+exec $START_CMD $START_CLASS

--- a/openshift-spark-build/modules/common/added/scripts/launch.sh
+++ b/openshift-spark-build/modules/common/added/scripts/launch.sh
@@ -35,11 +35,19 @@ else
     metrics=" with jolokia metrics enabled (deprecated, set SPARK_METRICS_ON to 'prometheus')"
 fi
 
+if [ ${USE_CGROUP_MEMORY} == "true" ]; then
+    SPARK_JAVA_OPTS=${SPARK_JAVA_OPTS:-"-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -XX:MaxRAMFraction=2 -XshowSettings:vm"}
+    START_CMD="java $JAVA_AGENT $SPARK_JAVA_OPTS -cp /opt/spark/conf/:/opt/spark/jars/*"
+else
+    START_CMD="$SPARK_HOME/bin/spark-class$JAVA_AGENT"
+fi
+
 if [ -z ${SPARK_MASTER_ADDRESS+_} ]; then
     echo "Starting master$metrics"
-    exec $SPARK_HOME/bin/spark-class$JAVA_AGENT org.apache.spark.deploy.master.Master
+    START_CLASS="org.apache.spark.deploy.master.Master $SPARK_MASTER_ADDRESS"
 else
     echo "Starting worker$metrics, will connect to: $SPARK_MASTER_ADDRESS"
+    START_CLASS="org.apache.spark.deploy.worker.Worker"
     while true; do
         echo "Waiting for spark master to be available ..."
         curl --connect-timeout 1 -s -X GET $SPARK_MASTER_UI_ADDRESS > /dev/null
@@ -48,5 +56,6 @@ else
         fi
         sleep 1
     done
-    exec $SPARK_HOME/bin/spark-class$JAVA_AGENT org.apache.spark.deploy.worker.Worker $SPARK_MASTER_ADDRESS
 fi
+
+exec $START_CMD $START_CLASS


### PR DESCRIPTION

So if there is `USE_CGROUP_MEMORY` set to `true`, it will bypass the `spark-class` script and start the worker or master with those two custom JVM options directly. If it's not set or set to `false` the previous approach is taken.

start two version of masters, one that is cgroups aware and 1 that is not:
```bash
docker run -d --rm --name=no-cg \
   --cap-add=SYS_PTRACE --security-opt seccomp=unconfined \
  jkremser/openshift-spark:cgroups

docker run -d --rm --name=cg --memory 500m -e USE_CGROUP_MEMORY=true \
  --cap-add=SYS_PTRACE --security-opt seccomp=unconfined \
 jkremser/openshift-spark:cgroups

# install jmap on both
docker exec --user 0 cg yum --enablerepo="*-debug*" install -y java-1.8.0-openjdk-devel java-1.8.0-openjdk-debuginfo
docker exec --user 0 no-cg yum --enablerepo="*-debug*" install -y java-1.8.0-openjdk-devel java-1.8.0-openjdk-debuginfo

# print the memory settings for JVM
echo -e "\n\n Heap config for cg:"
docker exec cg jmap -heap `docker exec cg jps -q | sort | head -1` | grep -C3 MaxHeapSize
echo -e "\n\n Heap config 4 no-cg:"
docker exec no-cg jmap -heap `docker exec no-cg jps -q | sort | head -1` | grep -C3 MaxHeapSize
```

note:
```
--cap-add=SYS_PTRACE --security-opt seccomp=unconfined
```
is there only for `jmap` to work properly, I like the output of jmap better than printing the low lvl stuff from either `/proc/pid/*`, `/sys/fs/cgroup/memory/memory.*` or `/proc/meminfo`. Because it shows the actual JVM memory allocations.