### PR TITLE
squash the docker images before pushing them manually to docker.io and quay.io

### DIFF
--- a/.travis.release.images.sh
+++ b/.travis.release.images.sh
@@ -1,0 +1,99 @@
+#!/bin/bash
+  
+set -xe
+
+OWNER="${OWNER:-radanalyticsio}"
+IMAGES="${IMAGES:-
+  openshift-spark
+  openshift-spark-py36
+  openshift-spark-inc
+  openshift-spark-py36-inc
+}"
+[ "$TRAVIS_BRANCH" = "master" -a "$TRAVIS_PULL_REQUEST" = "false" ] && LATEST=1
+
+main() {
+  if [[ "$LATEST" = "1" ]]; then
+    echo "Squashing and pushing the the :latest images to docker.io and quay.io"
+    installDockerSquash
+    loginDockerIo
+    pushLatestImages "docker.io"
+    loginQuayIo
+    pushLatestImages "quay.io"
+  elif [[ "${TRAVIS_TAG}" =~ ^[0-9]+\.[0-9]+\.[0-9]+-[0-9]+$ ]]; then
+    echo "Squashing and pushing the '${TRAVIS_TAG}' images to docker.io and quay.io"
+    installDockerSquash
+    loginDockerIo
+    pushReleaseImages "docker.io"
+    loginQuayIo
+    pushReleaseImages "quay.io"
+  else
+    echo "Not doing the docker push, because the tag '${TRAVIS_TAG}' is not of form x.y.z-n"
+  fi
+}
+
+loginDockerIo() {
+  set +x
+  docker login -u "$DOCKER_USERNAME" -p "$DOCKER_PASSWORD"
+  set -x
+}
+
+loginQuayIo() {
+  set +x
+  docker login -u "$QUAY_USERNAME" -p "$QUAY_PASSWORD" quay.io
+  set -x
+}
+
+installDockerSquash() {
+  command -v docker-squash || pip install --user docker-squash
+}
+
+squashAndPush() {
+  if [[ $# != 3 ]]; then
+    echo "Usage: squashAndPush input_image output_image" && exit
+  fi
+  local _in=$1
+  local _out=$2
+
+  echo "Squashing $_out.."
+  # squash last 22 layers (everything up to the base centos image)
+  docker-squash -F 22 -t $_out $in
+  docker push $_out
+}
+
+pushLatestImages() {
+  if [[ $# != 2 ]]; then
+    echo "Usage: pushLatestImages image_repo" && exit
+  fi
+  REPO="$1"
+
+  for image in $IMAGES ; do
+    squashAndPush $image "${REPO}/${OWNER}/${image}:latest"
+  done
+}
+
+pushReleaseImages() {
+  if [[ $# != 2 ]]; then
+    echo "Usage: pushReleaseImages image_repo" && exit
+  fi
+  REPO="$1"
+
+  for image in $IMAGES ; do
+    local _fully_qualified_image="${REPO}/${OWNER}/${image}:${TRAVIS_TAG}"
+    echo "Squashing $_fully_qualified_image.."
+
+    squashAndPush $image $_fully_qualified_image
+
+    # tag and push also x.y.z-latest image
+    local _x_y_z_latest=`echo ${TRAVIS_TAG} | cut -d'-' -f1`-latest
+    docker tag $_fully_qualified_image ${REPO}/${OWNER}/${image}:${_x_y_z_latest}
+    docker push ${REPO}/${OWNER}/${image}:${_x_y_z_latest}
+
+    # tag and push also :latest image
+    docker tag $_fully_qualified_image ${REPO}/${OWNER}/${image}:latest
+    docker push ${REPO}/${OWNER}/${image}:latest
+  done
+
+  docker logout
+}
+
+main

--- a/.travis.release.images.sh
+++ b/.travis.release.images.sh
@@ -12,7 +12,7 @@ IMAGES="${IMAGES:-
 
 main() {
   if [[ "$TRAVIS_BRANCH" = "master" -a "$TRAVIS_PULL_REQUEST" = "false" ]]; then
-    echo "Squashing and pushing the the :latest images to docker.io and quay.io"
+    echo "Squashing and pushing the :latest images to docker.io and quay.io"
     installDockerSquash
     loginDockerIo
     pushLatestImages "docker.io"
@@ -55,7 +55,7 @@ squashAndPush() {
 
   echo "Squashing $_out.."
   # squash last 22 layers (everything up to the base centos image)
-  docker-squash -F 22 -t $_out $in
+  docker-squash -f 22 -t $_out $in
   docker push $_out
 }
 

--- a/.travis.release.images.sh
+++ b/.travis.release.images.sh
@@ -9,10 +9,9 @@ IMAGES="${IMAGES:-
   openshift-spark-inc
   openshift-spark-py36-inc
 }"
-[ "$TRAVIS_BRANCH" = "master" -a "$TRAVIS_PULL_REQUEST" = "false" ] && LATEST=1
 
 main() {
-  if [[ "$LATEST" = "1" ]]; then
+  if [[ "$TRAVIS_BRANCH" = "master" -a "$TRAVIS_PULL_REQUEST" = "false" ]]; then
     echo "Squashing and pushing the the :latest images to docker.io and quay.io"
     installDockerSquash
     loginDockerIo
@@ -27,7 +26,7 @@ main() {
     loginQuayIo
     pushReleaseImages "quay.io"
   else
-    echo "Not doing the docker push, because the tag '${TRAVIS_TAG}' is not of form x.y.z-n"
+    echo "Not doing the docker push, because the tag '${TRAVIS_TAG}' is not of form x.y.z-n or we are not building the master branch"
   fi
 }
 

--- a/.travis.release.images.sh
+++ b/.travis.release.images.sh
@@ -82,8 +82,8 @@ pushReleaseImages() {
 
     squashAndPush $image $_fully_qualified_image
 
-    # tag and push also x.y.z-latest image
-    local _x_y_z_latest=`echo ${TRAVIS_TAG} | cut -d'-' -f1`-latest
+    # tag and push also x.y-latest image
+    local _x_y_z_latest=`echo ${TRAVIS_TAG} | sed -r 's;([[:digit:]]+\.[[:digit:]]+).*;\1-latest;'`
     docker tag $_fully_qualified_image ${REPO}/${OWNER}/${image}:${_x_y_z_latest}
     docker push ${REPO}/${OWNER}/${image}:${_x_y_z_latest}
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,11 @@ script:
 - if [ "$TO_TEST" = "openshift-spark-py36-inc" ]; then make -f Makefile.inc test-e2e-py36 ; fi
 - if [ "$TO_TEST" = "openshift-spark-comp" ]; then make -f Makefile.inc test-e2e-py-completed ; fi
 - if [ "$TO_TEST" = "openshift-spark-py36-comp" ]; then make -f Makefile.inc test-e2e-py36-completed ; fi
+deploy:
+  provider: script
+  script: ./.travis.release.images.sh
+  on:
+    branch: master
 notifications:
  email:
    on_success: never

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,8 +32,6 @@ script:
 deploy:
   provider: script
   script: ./.travis.release.images.sh
-  on:
-    branch: master
 notifications:
  email:
    on_success: never


### PR DESCRIPTION
This PR adds a script that for each image that we publish does `docker-squash` for the last 22 layers (23rd is the Centos base image layer) and pushes the image. For each commit to master it runs the same logic to create `:latest` images, for tags that matches the "regexp" x.y.z-n, it creates those image tags and also generates the `x.y.z-latest` so for instance if the git tag is `2.4.0-1`, it will create and push images for `:latest`, `2.4.0-1` and also `2.4-latest`.

profit if this is merged: images will be 300 megs smaller

todo:
- [ ] set the login and password env variables either by travis secrets or directly in the travis config (I don't have rights for this)
- [ ] turn-off the automatic dockerbuilds on docker.io and quay.io (this should be done after this is merged)
- [ ] verify that it actually works as expected (requires the two above to be done)

/cc @elmiko 