### PR TITLE
Remove quotes around command in entrypoint

### DIFF
--- a/modules/common/added/scripts/entrypoint
+++ b/modules/common/added/scripts/entrypoint
@@ -67,11 +67,11 @@ function patch_uid {
 # standard spark entrypoint
 case "$1" in
     driver | executor | init)
-        $SPARK_INSTALL/entrypoint.sh "$CMD" &
+        $SPARK_INSTALL/entrypoint.sh $CMD &
         ;;
     *)
         patch_uid
-        $SCL_ENABLE_CMD "$CMD" &
+        $SCL_ENABLE_CMD $CMD &
         ;;
 esac
 PID=$!

--- a/openshift-spark-build-inc-py36/Dockerfile
+++ b/openshift-spark-build-inc-py36/Dockerfile
@@ -18,8 +18,20 @@
 
 FROM centos:latest
 
+USER root
+
+
+# Install required RPMs and ensure that the packages were installed
+RUN yum install -y java-1.8.0-openjdk wget \
+    && yum clean all && rm -rf /var/cache/yum \
+    && rpm -q java-1.8.0-openjdk wget
+
+
+
 # Environment variables
 ENV \
+    JBOSS_IMAGE_NAME="radanalyticsio/openshift-spark-inc" \
+    JBOSS_IMAGE_VERSION="2.3-latest" \
     PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/spark/bin" \
     SCL_ENABLE_CMD="scl enable rh-python36" \
     SPARK_HOME="/opt/spark" \
@@ -28,20 +40,13 @@ ENV \
 
 # Labels
 LABEL \
-      io.cekit.version="2.1.4"  \
+      io.cekit.version="2.2.7"  \
       io.openshift.s2i.scripts-url="image:///usr/libexec/s2i"  \
       maintainer="Chad Roberts <croberts@redhat.com>"  \
-      org.concrt.version="2.1.4"  \
-      sparkversion="2.3.0" 
-
-
-USER root
-
-
-# Install required RPMs and ensure that the packages were installed
-RUN yum install -y java-1.8.0-openjdk wget \
-    && yum clean all && rm -rf /var/cache/yum && \
-    rpm -q  java-1.8.0-openjdk wget
+      name="radanalyticsio/openshift-spark-inc"  \
+      org.concrt.version="2.2.7"  \
+      sparkversion="2.3.0"  \
+      version="2.3-latest" 
 
 # Add scripts used to configure the image
 COPY modules /tmp/scripts

--- a/openshift-spark-build-inc-py36/help.md
+++ b/openshift-spark-build-inc-py36/help.md
@@ -11,6 +11,12 @@
 
 These environment variables are defined in the image.
 
+__JBOSS_IMAGE_NAME__
+>"radanalyticsio/openshift-spark-inc"
+
+__JBOSS_IMAGE_VERSION__
+>"2.3-latest"
+
 __PATH__
 >"/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/spark/bin"
 
@@ -37,7 +43,7 @@ when starting a container:
 ## Labels
 
 __io.cekit.version__
-> 2.1.4
+> 2.2.7
 
 __io.openshift.s2i.scripts-url__
 > image:///usr/libexec/s2i
@@ -45,10 +51,16 @@ __io.openshift.s2i.scripts-url__
 __maintainer__
 > Chad Roberts <croberts@redhat.com>
 
+__name__
+> radanalyticsio/openshift-spark-inc
+
 __org.concrt.version__
-> 2.1.4
+> 2.2.7
 
 __sparkversion__
 > 2.3.0
+
+__version__
+> 2.3-latest
 
 

--- a/openshift-spark-build-inc-py36/modules/common/added/scripts/entrypoint
+++ b/openshift-spark-build-inc-py36/modules/common/added/scripts/entrypoint
@@ -67,11 +67,11 @@ function patch_uid {
 # standard spark entrypoint
 case "$1" in
     driver | executor | init)
-        $SPARK_INSTALL/entrypoint.sh "$CMD" &
+        $SPARK_INSTALL/entrypoint.sh $CMD &
         ;;
     *)
         patch_uid
-        $SCL_ENABLE_CMD "$CMD" &
+        $SCL_ENABLE_CMD $CMD &
         ;;
 esac
 PID=$!

--- a/openshift-spark-build-inc/Dockerfile
+++ b/openshift-spark-build-inc/Dockerfile
@@ -18,8 +18,20 @@
 
 FROM centos:latest
 
+USER root
+
+
+# Install required RPMs and ensure that the packages were installed
+RUN yum install -y java-1.8.0-openjdk wget numpy \
+    && yum clean all && rm -rf /var/cache/yum \
+    && rpm -q java-1.8.0-openjdk wget numpy
+
+
+
 # Environment variables
 ENV \
+    JBOSS_IMAGE_NAME="radanalyticsio/openshift-spark-inc" \
+    JBOSS_IMAGE_VERSION="2.3-latest" \
     PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/spark/bin" \
     SCL_ENABLE_CMD="" \
     SPARK_HOME="/opt/spark" \
@@ -28,20 +40,13 @@ ENV \
 
 # Labels
 LABEL \
-      io.cekit.version="2.1.4"  \
+      io.cekit.version="2.2.7"  \
       io.openshift.s2i.scripts-url="image:///usr/libexec/s2i"  \
       maintainer="Chad Roberts <croberts@redhat.com>"  \
-      org.concrt.version="2.1.4"  \
-      sparkversion="2.3.0" 
-
-
-USER root
-
-
-# Install required RPMs and ensure that the packages were installed
-RUN yum install -y java-1.8.0-openjdk wget numpy \
-    && yum clean all && rm -rf /var/cache/yum && \
-    rpm -q  java-1.8.0-openjdk wget numpy
+      name="radanalyticsio/openshift-spark-inc"  \
+      org.concrt.version="2.2.7"  \
+      sparkversion="2.3.0"  \
+      version="2.3-latest" 
 
 # Add scripts used to configure the image
 COPY modules /tmp/scripts

--- a/openshift-spark-build-inc/help.md
+++ b/openshift-spark-build-inc/help.md
@@ -11,6 +11,12 @@
 
 These environment variables are defined in the image.
 
+__JBOSS_IMAGE_NAME__
+>"radanalyticsio/openshift-spark-inc"
+
+__JBOSS_IMAGE_VERSION__
+>"2.3-latest"
+
 __PATH__
 >"/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/spark/bin"
 
@@ -37,7 +43,7 @@ when starting a container:
 ## Labels
 
 __io.cekit.version__
-> 2.1.4
+> 2.2.7
 
 __io.openshift.s2i.scripts-url__
 > image:///usr/libexec/s2i
@@ -45,10 +51,16 @@ __io.openshift.s2i.scripts-url__
 __maintainer__
 > Chad Roberts <croberts@redhat.com>
 
+__name__
+> radanalyticsio/openshift-spark-inc
+
 __org.concrt.version__
-> 2.1.4
+> 2.2.7
 
 __sparkversion__
 > 2.3.0
+
+__version__
+> 2.3-latest
 
 

--- a/openshift-spark-build-inc/modules/common/added/scripts/entrypoint
+++ b/openshift-spark-build-inc/modules/common/added/scripts/entrypoint
@@ -67,11 +67,11 @@ function patch_uid {
 # standard spark entrypoint
 case "$1" in
     driver | executor | init)
-        $SPARK_INSTALL/entrypoint.sh "$CMD" &
+        $SPARK_INSTALL/entrypoint.sh $CMD &
         ;;
     *)
         patch_uid
-        $SCL_ENABLE_CMD "$CMD" &
+        $SCL_ENABLE_CMD $CMD &
         ;;
 esac
 PID=$!

--- a/openshift-spark-build-py36/Dockerfile
+++ b/openshift-spark-build-py36/Dockerfile
@@ -18,8 +18,26 @@
 
 FROM centos:latest
 
+USER root
+
+
+# Install required RPMs and ensure that the packages were installed
+RUN yum install -y java-1.8.0-openjdk wget \
+    && yum clean all && rm -rf /var/cache/yum \
+    && rpm -q java-1.8.0-openjdk wget
+
+
+# Add all artifacts to the /tmp/artifacts
+# directory
+COPY \
+    spark-2.3.0-bin-hadoop2.7.tgz \
+    /tmp/artifacts/
+
+
 # Environment variables
 ENV \
+    JBOSS_IMAGE_NAME="radanalyticsio/openshift-spark" \
+    JBOSS_IMAGE_VERSION="2.3-latest" \
     PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/spark/bin" \
     SCL_ENABLE_CMD="scl enable rh-python36" \
     SPARK_HOME="/opt/spark" \
@@ -28,26 +46,13 @@ ENV \
 
 # Labels
 LABEL \
-      io.cekit.version="2.1.4"  \
+      io.cekit.version="2.2.7"  \
       io.openshift.s2i.scripts-url="image:///usr/libexec/s2i"  \
       maintainer="Chad Roberts <croberts@redhat.com>"  \
-      org.concrt.version="2.1.4"  \
-      sparkversion="2.3.0" 
-
-
-USER root
-
-
-# Install required RPMs and ensure that the packages were installed
-RUN yum install -y java-1.8.0-openjdk wget \
-    && yum clean all && rm -rf /var/cache/yum && \
-    rpm -q  java-1.8.0-openjdk wget
-
-# Add all artifacts to the /tmp/artifacts
-# directory
-COPY \
-    spark-2.3.0-bin-hadoop2.7.tgz \
-    /tmp/artifacts/
+      name="radanalyticsio/openshift-spark"  \
+      org.concrt.version="2.2.7"  \
+      sparkversion="2.3.0"  \
+      version="2.3-latest" 
 
 # Add scripts used to configure the image
 COPY modules /tmp/scripts

--- a/openshift-spark-build-py36/help.md
+++ b/openshift-spark-build-py36/help.md
@@ -11,6 +11,12 @@
 
 These environment variables are defined in the image.
 
+__JBOSS_IMAGE_NAME__
+>"radanalyticsio/openshift-spark"
+
+__JBOSS_IMAGE_VERSION__
+>"2.3-latest"
+
 __PATH__
 >"/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/spark/bin"
 
@@ -37,7 +43,7 @@ when starting a container:
 ## Labels
 
 __io.cekit.version__
-> 2.1.4
+> 2.2.7
 
 __io.openshift.s2i.scripts-url__
 > image:///usr/libexec/s2i
@@ -45,10 +51,16 @@ __io.openshift.s2i.scripts-url__
 __maintainer__
 > Chad Roberts <croberts@redhat.com>
 
+__name__
+> radanalyticsio/openshift-spark
+
 __org.concrt.version__
-> 2.1.4
+> 2.2.7
 
 __sparkversion__
 > 2.3.0
+
+__version__
+> 2.3-latest
 
 

--- a/openshift-spark-build-py36/modules/common/added/scripts/entrypoint
+++ b/openshift-spark-build-py36/modules/common/added/scripts/entrypoint
@@ -67,11 +67,11 @@ function patch_uid {
 # standard spark entrypoint
 case "$1" in
     driver | executor | init)
-        $SPARK_INSTALL/entrypoint.sh "$CMD" &
+        $SPARK_INSTALL/entrypoint.sh $CMD &
         ;;
     *)
         patch_uid
-        $SCL_ENABLE_CMD "$CMD" &
+        $SCL_ENABLE_CMD $CMD &
         ;;
 esac
 PID=$!

--- a/openshift-spark-build/Dockerfile
+++ b/openshift-spark-build/Dockerfile
@@ -18,8 +18,26 @@
 
 FROM centos:latest
 
+USER root
+
+
+# Install required RPMs and ensure that the packages were installed
+RUN yum install -y java-1.8.0-openjdk wget numpy \
+    && yum clean all && rm -rf /var/cache/yum \
+    && rpm -q java-1.8.0-openjdk wget numpy
+
+
+# Add all artifacts to the /tmp/artifacts
+# directory
+COPY \
+    spark-2.3.0-bin-hadoop2.7.tgz \
+    /tmp/artifacts/
+
+
 # Environment variables
 ENV \
+    JBOSS_IMAGE_NAME="radanalyticsio/openshift-spark" \
+    JBOSS_IMAGE_VERSION="2.3-latest" \
     PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/spark/bin" \
     SCL_ENABLE_CMD="" \
     SPARK_HOME="/opt/spark" \
@@ -28,26 +46,13 @@ ENV \
 
 # Labels
 LABEL \
-      io.cekit.version="2.1.4"  \
+      io.cekit.version="2.2.7"  \
       io.openshift.s2i.scripts-url="image:///usr/libexec/s2i"  \
       maintainer="Chad Roberts <croberts@redhat.com>"  \
-      org.concrt.version="2.1.4"  \
-      sparkversion="2.3.0" 
-
-
-USER root
-
-
-# Install required RPMs and ensure that the packages were installed
-RUN yum install -y java-1.8.0-openjdk wget numpy \
-    && yum clean all && rm -rf /var/cache/yum && \
-    rpm -q  java-1.8.0-openjdk wget numpy
-
-# Add all artifacts to the /tmp/artifacts
-# directory
-COPY \
-    spark-2.3.0-bin-hadoop2.7.tgz \
-    /tmp/artifacts/
+      name="radanalyticsio/openshift-spark"  \
+      org.concrt.version="2.2.7"  \
+      sparkversion="2.3.0"  \
+      version="2.3-latest" 
 
 # Add scripts used to configure the image
 COPY modules /tmp/scripts

--- a/openshift-spark-build/help.md
+++ b/openshift-spark-build/help.md
@@ -11,6 +11,12 @@
 
 These environment variables are defined in the image.
 
+__JBOSS_IMAGE_NAME__
+>"radanalyticsio/openshift-spark"
+
+__JBOSS_IMAGE_VERSION__
+>"2.3-latest"
+
 __PATH__
 >"/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/spark/bin"
 
@@ -37,7 +43,7 @@ when starting a container:
 ## Labels
 
 __io.cekit.version__
-> 2.1.4
+> 2.2.7
 
 __io.openshift.s2i.scripts-url__
 > image:///usr/libexec/s2i
@@ -45,10 +51,16 @@ __io.openshift.s2i.scripts-url__
 __maintainer__
 > Chad Roberts <croberts@redhat.com>
 
+__name__
+> radanalyticsio/openshift-spark
+
 __org.concrt.version__
-> 2.1.4
+> 2.2.7
 
 __sparkversion__
 > 2.3.0
+
+__version__
+> 2.3-latest
 
 

--- a/openshift-spark-build/modules/common/added/scripts/entrypoint
+++ b/openshift-spark-build/modules/common/added/scripts/entrypoint
@@ -67,11 +67,11 @@ function patch_uid {
 # standard spark entrypoint
 case "$1" in
     driver | executor | init)
-        $SPARK_INSTALL/entrypoint.sh "$CMD" &
+        $SPARK_INSTALL/entrypoint.sh $CMD &
         ;;
     *)
         patch_uid
-        $SCL_ENABLE_CMD "$CMD" &
+        $SCL_ENABLE_CMD $CMD &
         ;;
 esac
 PID=$!


### PR DESCRIPTION
Quotes around $CMD in the invocations at the end of the script cause multi-word commands to be interpreted by bash as an atomic unit, and result in "No file found" type errors.  Dropping the quotes lets the commands work correctly in these cases.