### PR TITLE
typo in the .travis.release.images.sh

### DIFF
--- a/.travis.release.images.sh
+++ b/.travis.release.images.sh
@@ -13,6 +13,7 @@ IMAGES="${IMAGES:-
 main() {
   if [[ "$TRAVIS_BRANCH" = "master" && "$TRAVIS_PULL_REQUEST" = "false" ]]; then
     echo "Squashing and pushing the :latest images to docker.io and quay.io"
+    buildImages
     installDockerSquash
     loginDockerIo
     pushLatestImages "docker.io"
@@ -20,6 +21,7 @@ main() {
     pushLatestImages "quay.io"
   elif [[ "${TRAVIS_TAG}" =~ ^[0-9]+\.[0-9]+\.[0-9]+-[0-9]+$ ]]; then
     echo "Squashing and pushing the '${TRAVIS_TAG}' images to docker.io and quay.io"
+    buildImages
     installDockerSquash
     loginDockerIo
     pushReleaseImages "docker.io"
@@ -28,6 +30,11 @@ main() {
   else
     echo "Not doing the docker push, because the tag '${TRAVIS_TAG}' is not of form x.y.z-n or we are not building the master branch"
   fi
+}
+
+buildImages() {
+  make build-py build-py36
+  make -f Makefile.inc build-py build-py36
 }
 
 loginDockerIo() {

--- a/.travis.release.images.sh
+++ b/.travis.release.images.sh
@@ -11,7 +11,7 @@ IMAGES="${IMAGES:-
 }"
 
 main() {
-  if [[ "$TRAVIS_BRANCH" = "master" -a "$TRAVIS_PULL_REQUEST" = "false" ]]; then
+  if [[ "$TRAVIS_BRANCH" = "master" && "$TRAVIS_PULL_REQUEST" = "false" ]]; then
     echo "Squashing and pushing the :latest images to docker.io and quay.io"
     installDockerSquash
     loginDockerIo

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,15 +4,9 @@ language: go
 ## home folder is /home/travis/gopath/src/github.com/radanalyticsio/oshinko-cli
 services:
 - docker
-matrix:
-  include:
-    - env: TO_TEST=openshift-spark OPENSHIFT_VERSION=v3.10
-    - env: TO_TEST=openshift-spark-py36 OPENSHIFT_VERSION=v3.10
-    - env: TO_TEST=openshift-spark-inc OPENSHIFT_VERSION=v3.10
-    - env: TO_TEST=openshift-spark-py36-inc OPENSHIFT_VERSION=v3.10
-    - env: TO_TEST=openshift-spark-comp OPENSHIFT_VERSION=v3.10
-    - env: TO_TEST=openshift-spark-py36-comp OPENSHIFT_VERSION=v3.10
-  fast_finish: true
+stages:
+  - Openshift tests
+  - deploy
 
 before_install:
 - pwd
@@ -20,18 +14,35 @@ before_install:
 - sudo apt-get install --only-upgrade bash
 - bash --version
 - test/prepare.sh
-install:
-before_script:
-script:
-- if [ "$TO_TEST" = "openshift-spark" ]; then make test-e2e-py ; fi
-- if [ "$TO_TEST" = "openshift-spark-py36" ]; then make test-e2e-py36 ; fi
-- if [ "$TO_TEST" = "openshift-spark-inc" ]; then make -f Makefile.inc test-e2e-py ; fi
-- if [ "$TO_TEST" = "openshift-spark-py36-inc" ]; then make -f Makefile.inc test-e2e-py36 ; fi
-- if [ "$TO_TEST" = "openshift-spark-comp" ]; then make -f Makefile.inc test-e2e-py-completed ; fi
-- if [ "$TO_TEST" = "openshift-spark-py36-comp" ]; then make -f Makefile.inc test-e2e-py36-completed ; fi
-deploy:
-  provider: script
-  script: ./.travis.release.images.sh
+
+env:
+  global: OPENSHIFT_VERSION="v3.10"
+
+jobs:
+  include:
+  - stage: Openshift tests
+    name: openshift-spark
+    script: make test-e2e-py
+
+  - name: openshift-spark-py36
+    script: make test-e2e-py36
+
+  - name: openshift-spark-inc
+    script: make -f Makefile.inc test-e2e-py
+
+  - name: openshift-spark-py36-inc
+    script: make -f Makefile.inc test-e2e-py36
+
+  - name: openshift-spark-comp
+    script: make -f Makefile.inc test-e2e-py-completed
+
+  - name: openshift-spark-py36-comp
+    script: make -f Makefile.inc test-e2e-py36-completed
+
+  - stage: deploy
+    name: "Push container images"
+    script: ./.travis.release.images.sh
+
 notifications:
  email:
    on_success: never


### PR DESCRIPTION
Fixing the typo in the `.travis.release.images.sh`
dbd5a759e:
```
[[ c1 -a c2 ]] --> [[ c1 -&& c2 ]]
```

d7e9cf9bf:
With the previous `.travis.yml` file, the deploy stage was run for each permutation of the matrix. This commit rewrites it from the matrix definition into explicit build stages.

b3ee5c98d:
Since the deploy and test stage do not share the same instance on AWS, the previously built docker images are not visible during the deploy stage and they need to be built again (or shared using travis cache, but this brings another set of problems). Building it again is relatively fast.

This is how the build looks like in travis:
![b8X68nk](https://user-images.githubusercontent.com/535866/58191255-75976f80-7cbe-11e9-8cf1-6fe0fa10a349.png)

https://travis-ci.org/radanalyticsio/openshift-spark/builds/535857574