### PR TITLE
Allow a modify-spark directory for image completion

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,19 +80,33 @@ the [s2i tool](https://github.com/openshift/source-to-image) if it's installed.
 The final images created can be used just like the `openshfit-spark` and
 `openshift-spark-py36` images described above.
 
+### Build inputs
+
+The OpenShift method can take either local files or a URL as build input.
+For the s2i method, local files are required. Here is an example which
+downloads an Apache Spark distribution to a local 'build-input' directory
+(including the sha512 file is optional).
+
+    $ mkdir build-input
+    $ wget https://archive.apache.org/dist/spark/spark-2.4.0/spark-2.4.0-bin-hadoop2.7.tgz -O build-input/spark-2.4.0-bin-hadoop2.7.tgz
+    $ wget https://archive.apache.org/dist/spark/spark-2.4.0/spark-2.4.0-bin-hadoop2.7.tgz.sha512 -O build-input/spark-2.4.0-bin-hadoop2.7.tgz.sha512
+
+Optionally, your `build-input` directory may contain a `modify-spark` directory. The structure of this directory should be parallel to the structure
+of the top-level directory in the Spark distribution tarball. During the installation, the contents of this directory will be copied to the Spark
+installation using `rsync`, allowing you to add or overwrite files. To add `my.jar` to Spark, for example, put it in  `build-input/modify-spark/jars/my.jar`
+
+### Running the image completion
+
 To complete the Python 2.7 image using the [s2i tool](https://github.com/openshift/source-to-image)
 
-    $ mkdir build_input
-    $ wget https://archive.apache.org/dist/spark/spark-2.3.0/spark-2.3.0-bin-hadoop2.7.tgz -O build_input/spark-2.3.0-bin-hadoop2.7.tgz
-    $ wget https://archive.apache.org/dist/spark/spark-2.3.0/spark-2.3.0-bin-hadoop2.7.tgz.md5 -O build_input/spark-2.3.0-bin-hadoop2.7.tgz.md5
-    $ s2i build build_input radanalyticsio/openshift-spark-inc openshift-spark
+    $ s2i build build-input radanalyticsio/openshift-spark-inc openshift-spark
 
 To complete the Python 2.7 image using OpenShift, for example:
 
     $ oc new-build --name=openshift-spark --docker-image=radanalyticsio/openshift-spark-inc --binary
-    $ oc start-build openshift-spark --from-file=https://archive.apache.org/dist/spark/spark-2.3.0/spark-2.3.0-bin-hadoop2.7.tgz
+    $ oc start-build openshift-spark --from-file=https://archive.apache.org/dist/spark/spark-2.4.0/spark-2.4.0-bin-hadoop2.7.tgz
 
-    (note that the value of `--from-file` could also be the `build_input` directory from the s2i example above)
+    Note that the value of `--from-file` could also be the `build-input` directory from the s2i example above.
 
 This will write the completed image to an imagestream called `openshift-spark` in the current project
 

--- a/image-inc.yaml
+++ b/image-inc.yaml
@@ -31,6 +31,7 @@ packages:
     install:
         - java-1.8.0-openjdk
         - wget
+        - rsync
 run:
     user: 185
     entrypoint:

--- a/modules/s2i/added/assemble
+++ b/modules/s2i/added/assemble
@@ -138,6 +138,12 @@ else
         done
         popd &> /dev/null
 
+	# If someone included mods in a parallel directory, install them with rsync
+        if [ -d "$S2I_SOURCE_DIR/modify-spark" ]; then
+	    echo Found a modify-spark directory, running rsync to install changes
+	    rsync -av "$S2I_SOURCE_DIR/modify-spark/" $SPARK_HOME
+        fi
+
         # Can we run spark-submit?
         $SPARK_HOME/bin/spark-submit --version
         if [ "$?" -eq 0 ]; then

--- a/modules/s2i/added/assemble
+++ b/modules/s2i/added/assemble
@@ -139,7 +139,7 @@ else
         popd &> /dev/null
 
 	# If someone included mods in a parallel directory, install them with rsync
-        if [ -d "$S2I_SOURCE_DIR/modify-spark" ]; then
+        if [ -x /usr/bin/rsync ] && [ -d "$S2I_SOURCE_DIR/modify-spark" ]; then
 	    echo Found a modify-spark directory, running rsync to install changes
 	    rsync -av "$S2I_SOURCE_DIR/modify-spark/" $SPARK_HOME
         fi

--- a/modules/s2i/added/usage
+++ b/modules/s2i/added/usage
@@ -50,7 +50,7 @@ downloads an Apache Spark distribution to a local 'build-input' directory
 
 $ mkdir build-input
 $ wget https://archive.apache.org/dist/spark/spark-2.4.0/spark-2.4.0-bin-hadoop2.7.tgz -O build-input/spark-2.4.0-bin-hadoop2.7.tgz
-$ wget https://archive.apache.org/dist/spark/spark-2.4.0/spark-2.4.0-bin-hadoop2.7.tgz.sha512 -O build-input/spark-2.4.0-bin-hadoop2.7.tgz.md5
+$ wget https://archive.apache.org/dist/spark/spark-2.4.0/spark-2.4.0-bin-hadoop2.7.tgz.sha512 -O build-input/spark-2.4.0-bin-hadoop2.7.tgz.sha512
 
 Optionally, your `build-input` directory may contain a modify-spark directory. The structure of this directory should be parallel to the structure
 of the top-level directory in the Spark distribution tarball. The contents of this directory will be copied to the Spark installation using rsync,

--- a/modules/s2i/added/usage
+++ b/modules/s2i/added/usage
@@ -45,12 +45,16 @@ Build inputs:
 
 The OpenShift method can take either local files or a URL as build input.
 For the s2i method, local files are required. Here is an example which
-downloads an Apache Spark distribution to a local 'build_input' directory
-(including the md5 file is optional).
+downloads an Apache Spark distribution to a local 'build-input' directory
+(including the sha512 file is optional).
 
-$ mkdir build_input
-$ wget https://archive.apache.org/dist/spark/spark-2.3.0/spark-2.3.0-bin-hadoop2.7.tgz -O build_input/spark-2.3.0-bin-hadoop2.7.tgz
-$ wget https://archive.apache.org/dist/spark/spark-2.3.0/spark-2.3.0-bin-hadoop2.7.tgz.md5 -O build_input/spark-2.3.0-bin-hadoop2.7.tgz.md5
+$ mkdir build-input
+$ wget https://archive.apache.org/dist/spark/spark-2.4.0/spark-2.4.0-bin-hadoop2.7.tgz -O build-input/spark-2.4.0-bin-hadoop2.7.tgz
+$ wget https://archive.apache.org/dist/spark/spark-2.4.0/spark-2.4.0-bin-hadoop2.7.tgz.sha512 -O build-input/spark-2.4.0-bin-hadoop2.7.tgz.md5
+
+Optionally, your `build-input` directory may contain a modify-spark directory. The structure of this directory should be parallel to the structure
+of the top-level directory in the Spark distribution tarball. The contents of this directory will be copied to the Spark installation using rsync,
+allowing you to add or overwrite files. To add my.jar to Spark, for example, put it in build-input/modify-spark/jars/my.jar
 
 Completing the image with OpenShift:
 ------------------------------------
@@ -58,7 +62,7 @@ Completing the image with OpenShift:
 Run a binary build specifying the spark distribution, for example:
 
 $ oc new-build --name=openshift-spark --docker-image=radanalyticsio/openshift-spark-inc --binary
-$ oc start-build openshift-spark --from-file=https://archive.apache.org/dist/spark/spark-2.3.0/spark-2.3.0-bin-hadoop2.7.tgz
+$ oc start-build openshift-spark --from-file=https://archive.apache.org/dist/spark/spark-2.4.0/spark-2.4.0-bin-hadoop2.7.tgz
 
 This will write the completed image to an imagestream called 'openshift-spark'
 in the current project. Note that the value of --from-file can also be a local
@@ -67,7 +71,7 @@ directory (see Build Inputs above).
 Completing the image with the s2i tool:
 ---------------------------------------
 
-s2i build build_input radanalyticsio/openshift-spark-inc openshift-spark
+s2i build build-input radanalyticsio/openshift-spark-inc openshift-spark
 
 This will build a local image named 'openshift-spark:latest' which can
 then be uploaded to an image repository.

--- a/openshift-spark-build-inc-py36/Dockerfile
+++ b/openshift-spark-build-inc-py36/Dockerfile
@@ -18,41 +18,40 @@
 
 FROM centos:latest
 
+USER root
+
+
+# Install required RPMs and ensure that the packages were installed
+RUN yum install -y java-1.8.0-openjdk wget rsync \
+    && yum clean all && rm -rf /var/cache/yum \
+    && rpm -q java-1.8.0-openjdk wget rsync
+
+
+
 # Environment variables
-ENV JBOSS_IMAGE_NAME="radanalyticsio/openshift-spark-inc" \
+ENV \
+    JBOSS_IMAGE_NAME="radanalyticsio/openshift-spark-inc" \
     JBOSS_IMAGE_VERSION="2.4-latest" \
-    SCL_ENABLE_CMD="scl enable rh-python36" \
     PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/spark/bin" \
+    SCL_ENABLE_CMD="scl enable rh-python36" \
     SPARK_HOME="/opt/spark" \
     SPARK_INSTALL="/opt/spark-distro" \
     STI_SCRIPTS_PATH="/usr/libexec/s2i" 
 
 # Labels
-LABEL name="$JBOSS_IMAGE_NAME" \
-      version="$JBOSS_IMAGE_VERSION" \
-      architecture="x86_64"  \
-      com.redhat.component="radanalyticsio-openshift-spark-inc-docker"  \
-      org.concrt.version="1.4.1" \
-      maintainer="Chad Roberts <croberts@redhat.com>" \
-      sparkversion="2.4.0" \
-      io.openshift.s2i.scripts-url="image:///usr/libexec/s2i"
-
-
-USER root
-
-
-# Install required RPMs and ensure that the packages were installed
-RUN yum install -y  java-1.8.0-openjdk wget \
-    && yum clean all && \
-    rpm -q  java-1.8.0-openjdk wget
+LABEL \
+      io.cekit.version="2.2.7"  \
+      io.openshift.s2i.scripts-url="image:///usr/libexec/s2i"  \
+      maintainer="Chad Roberts <croberts@redhat.com>"  \
+      name="radanalyticsio/openshift-spark-inc"  \
+      org.concrt.version="2.2.7"  \
+      sparkversion="2.4.0"  \
+      version="2.4-latest" 
 
 # Add scripts used to configure the image
 COPY modules /tmp/scripts
 
 # Custom scripts
-USER root
-RUN [ "bash", "-x", "/tmp/scripts/python36/install" ]
-
 USER root
 RUN [ "bash", "-x", "/tmp/scripts/common/install" ]
 
@@ -63,6 +62,9 @@ USER root
 RUN [ "bash", "-x", "/tmp/scripts/s2i/install" ]
 
 USER root
+RUN [ "bash", "-x", "/tmp/scripts/python36/install" ]
+
+USER root
 RUN rm -rf /tmp/scripts
 
 USER 185
@@ -71,3 +73,4 @@ USER 185
 ENTRYPOINT ["/entrypoint"]
 
 CMD ["/usr/libexec/s2i/usage"]
+

--- a/openshift-spark-build-inc-py36/help.md
+++ b/openshift-spark-build-inc-py36/help.md
@@ -1,0 +1,66 @@
+# radanalyticsio/openshift-spark-inc
+
+## Description
+
+
+
+
+## Environment variables
+
+### Informational
+
+These environment variables are defined in the image.
+
+__JBOSS_IMAGE_NAME__
+>"radanalyticsio/openshift-spark-inc"
+
+__JBOSS_IMAGE_VERSION__
+>"2.4-latest"
+
+__PATH__
+>"/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/spark/bin"
+
+__SCL_ENABLE_CMD__
+>"scl enable rh-python36"
+
+__SPARK_HOME__
+>"/opt/spark"
+
+__SPARK_INSTALL__
+>"/opt/spark-distro"
+
+__STI_SCRIPTS_PATH__
+>"/usr/libexec/s2i"
+
+
+### Configuration
+
+The image can be configured by defining these environment variables
+when starting a container:
+
+
+
+## Labels
+
+__io.cekit.version__
+> 2.2.7
+
+__io.openshift.s2i.scripts-url__
+> image:///usr/libexec/s2i
+
+__maintainer__
+> Chad Roberts <croberts@redhat.com>
+
+__name__
+> radanalyticsio/openshift-spark-inc
+
+__org.concrt.version__
+> 2.2.7
+
+__sparkversion__
+> 2.4.0
+
+__version__
+> 2.4-latest
+
+

--- a/openshift-spark-build-inc-py36/modules/s2i/added/assemble
+++ b/openshift-spark-build-inc-py36/modules/s2i/added/assemble
@@ -138,6 +138,12 @@ else
         done
         popd &> /dev/null
 
+	# If someone included mods in a parallel directory, install them with rsync
+        if [ -d "$S2I_SOURCE_DIR/modify-spark" ]; then
+	    echo Found a modify-spark directory, running rsync to install changes
+	    rsync -av "$S2I_SOURCE_DIR/modify-spark/" $SPARK_HOME
+        fi
+
         # Can we run spark-submit?
         $SPARK_HOME/bin/spark-submit --version
         if [ "$?" -eq 0 ]; then

--- a/openshift-spark-build-inc-py36/modules/s2i/added/assemble
+++ b/openshift-spark-build-inc-py36/modules/s2i/added/assemble
@@ -139,7 +139,7 @@ else
         popd &> /dev/null
 
 	# If someone included mods in a parallel directory, install them with rsync
-        if [ -d "$S2I_SOURCE_DIR/modify-spark" ]; then
+        if [ -x /usr/bin/rsync ] && [ -d "$S2I_SOURCE_DIR/modify-spark" ]; then
 	    echo Found a modify-spark directory, running rsync to install changes
 	    rsync -av "$S2I_SOURCE_DIR/modify-spark/" $SPARK_HOME
         fi

--- a/openshift-spark-build-inc-py36/modules/s2i/added/usage
+++ b/openshift-spark-build-inc-py36/modules/s2i/added/usage
@@ -45,12 +45,16 @@ Build inputs:
 
 The OpenShift method can take either local files or a URL as build input.
 For the s2i method, local files are required. Here is an example which
-downloads an Apache Spark distribution to a local 'build_input' directory
-(including the md5 file is optional).
+downloads an Apache Spark distribution to a local 'build-input' directory
+(including the sha512 file is optional).
 
-$ mkdir build_input
-$ wget https://archive.apache.org/dist/spark/spark-2.3.0/spark-2.3.0-bin-hadoop2.7.tgz -O build_input/spark-2.3.0-bin-hadoop2.7.tgz
-$ wget https://archive.apache.org/dist/spark/spark-2.3.0/spark-2.3.0-bin-hadoop2.7.tgz.md5 -O build_input/spark-2.3.0-bin-hadoop2.7.tgz.md5
+$ mkdir build-input
+$ wget https://archive.apache.org/dist/spark/spark-2.4.0/spark-2.4.0-bin-hadoop2.7.tgz -O build-input/spark-2.4.0-bin-hadoop2.7.tgz
+$ wget https://archive.apache.org/dist/spark/spark-2.4.0/spark-2.4.0-bin-hadoop2.7.tgz.sha512 -O build-input/spark-2.4.0-bin-hadoop2.7.tgz.sha512
+
+Optionally, your `build-input` directory may contain a modify-spark directory. The structure of this directory should be parallel to the structure
+of the top-level directory in the Spark distribution tarball. The contents of this directory will be copied to the Spark installation using rsync,
+allowing you to add or overwrite files. To add my.jar to Spark, for example, put it in build-input/modify-spark/jars/my.jar
 
 Completing the image with OpenShift:
 ------------------------------------
@@ -58,7 +62,7 @@ Completing the image with OpenShift:
 Run a binary build specifying the spark distribution, for example:
 
 $ oc new-build --name=openshift-spark --docker-image=radanalyticsio/openshift-spark-inc --binary
-$ oc start-build openshift-spark --from-file=https://archive.apache.org/dist/spark/spark-2.3.0/spark-2.3.0-bin-hadoop2.7.tgz
+$ oc start-build openshift-spark --from-file=https://archive.apache.org/dist/spark/spark-2.4.0/spark-2.4.0-bin-hadoop2.7.tgz
 
 This will write the completed image to an imagestream called 'openshift-spark'
 in the current project. Note that the value of --from-file can also be a local
@@ -67,7 +71,7 @@ directory (see Build Inputs above).
 Completing the image with the s2i tool:
 ---------------------------------------
 
-s2i build build_input radanalyticsio/openshift-spark-inc openshift-spark
+s2i build build-input radanalyticsio/openshift-spark-inc openshift-spark
 
 This will build a local image named 'openshift-spark:latest' which can
 then be uploaded to an image repository.

--- a/openshift-spark-build-inc/Dockerfile
+++ b/openshift-spark-build-inc/Dockerfile
@@ -18,33 +18,35 @@
 
 FROM centos:latest
 
-# Environment variables
-ENV JBOSS_IMAGE_NAME="radanalyticsio/openshift-spark-inc" \
-    JBOSS_IMAGE_VERSION="2.4-latest" \
-    PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/spark/bin" \
-    SPARK_HOME="/opt/spark" \
-    SPARK_INSTALL="/opt/spark-distro" \
-    STI_SCRIPTS_PATH="/usr/libexec/s2i" \
-    SCL_ENABLE_CMD="" 
-
-# Labels
-LABEL name="$JBOSS_IMAGE_NAME" \
-      version="$JBOSS_IMAGE_VERSION" \
-      architecture="x86_64"  \
-      com.redhat.component="radanalyticsio-openshift-spark-inc-docker"  \
-      org.concrt.version="1.4.1" \
-      maintainer="Chad Roberts <croberts@redhat.com>" \
-      sparkversion="2.4.0" \
-      io.openshift.s2i.scripts-url="image:///usr/libexec/s2i"
-
-
 USER root
 
 
 # Install required RPMs and ensure that the packages were installed
-RUN yum install -y  numpy java-1.8.0-openjdk wget \
-    && yum clean all && \
-    rpm -q  numpy java-1.8.0-openjdk wget
+RUN yum install -y java-1.8.0-openjdk wget rsync numpy \
+    && yum clean all && rm -rf /var/cache/yum \
+    && rpm -q java-1.8.0-openjdk wget rsync numpy
+
+
+
+# Environment variables
+ENV \
+    JBOSS_IMAGE_NAME="radanalyticsio/openshift-spark-inc" \
+    JBOSS_IMAGE_VERSION="2.4-latest" \
+    PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/spark/bin" \
+    SCL_ENABLE_CMD="" \
+    SPARK_HOME="/opt/spark" \
+    SPARK_INSTALL="/opt/spark-distro" \
+    STI_SCRIPTS_PATH="/usr/libexec/s2i" 
+
+# Labels
+LABEL \
+      io.cekit.version="2.2.7"  \
+      io.openshift.s2i.scripts-url="image:///usr/libexec/s2i"  \
+      maintainer="Chad Roberts <croberts@redhat.com>"  \
+      name="radanalyticsio/openshift-spark-inc"  \
+      org.concrt.version="2.2.7"  \
+      sparkversion="2.4.0"  \
+      version="2.4-latest" 
 
 # Add scripts used to configure the image
 COPY modules /tmp/scripts
@@ -68,3 +70,4 @@ USER 185
 ENTRYPOINT ["/entrypoint"]
 
 CMD ["/usr/libexec/s2i/usage"]
+

--- a/openshift-spark-build-inc/help.md
+++ b/openshift-spark-build-inc/help.md
@@ -1,0 +1,66 @@
+# radanalyticsio/openshift-spark-inc
+
+## Description
+
+
+
+
+## Environment variables
+
+### Informational
+
+These environment variables are defined in the image.
+
+__JBOSS_IMAGE_NAME__
+>"radanalyticsio/openshift-spark-inc"
+
+__JBOSS_IMAGE_VERSION__
+>"2.4-latest"
+
+__PATH__
+>"/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/spark/bin"
+
+__SCL_ENABLE_CMD__
+>""
+
+__SPARK_HOME__
+>"/opt/spark"
+
+__SPARK_INSTALL__
+>"/opt/spark-distro"
+
+__STI_SCRIPTS_PATH__
+>"/usr/libexec/s2i"
+
+
+### Configuration
+
+The image can be configured by defining these environment variables
+when starting a container:
+
+
+
+## Labels
+
+__io.cekit.version__
+> 2.2.7
+
+__io.openshift.s2i.scripts-url__
+> image:///usr/libexec/s2i
+
+__maintainer__
+> Chad Roberts <croberts@redhat.com>
+
+__name__
+> radanalyticsio/openshift-spark-inc
+
+__org.concrt.version__
+> 2.2.7
+
+__sparkversion__
+> 2.4.0
+
+__version__
+> 2.4-latest
+
+

--- a/openshift-spark-build-inc/modules/s2i/added/assemble
+++ b/openshift-spark-build-inc/modules/s2i/added/assemble
@@ -138,6 +138,12 @@ else
         done
         popd &> /dev/null
 
+	# If someone included mods in a parallel directory, install them with rsync
+        if [ -d "$S2I_SOURCE_DIR/modify-spark" ]; then
+	    echo Found a modify-spark directory, running rsync to install changes
+	    rsync -av "$S2I_SOURCE_DIR/modify-spark/" $SPARK_HOME
+        fi
+
         # Can we run spark-submit?
         $SPARK_HOME/bin/spark-submit --version
         if [ "$?" -eq 0 ]; then

--- a/openshift-spark-build-inc/modules/s2i/added/assemble
+++ b/openshift-spark-build-inc/modules/s2i/added/assemble
@@ -139,7 +139,7 @@ else
         popd &> /dev/null
 
 	# If someone included mods in a parallel directory, install them with rsync
-        if [ -d "$S2I_SOURCE_DIR/modify-spark" ]; then
+        if [ -x /usr/bin/rsync ] && [ -d "$S2I_SOURCE_DIR/modify-spark" ]; then
 	    echo Found a modify-spark directory, running rsync to install changes
 	    rsync -av "$S2I_SOURCE_DIR/modify-spark/" $SPARK_HOME
         fi

--- a/openshift-spark-build-inc/modules/s2i/added/usage
+++ b/openshift-spark-build-inc/modules/s2i/added/usage
@@ -45,12 +45,16 @@ Build inputs:
 
 The OpenShift method can take either local files or a URL as build input.
 For the s2i method, local files are required. Here is an example which
-downloads an Apache Spark distribution to a local 'build_input' directory
-(including the md5 file is optional).
+downloads an Apache Spark distribution to a local 'build-input' directory
+(including the sha512 file is optional).
 
-$ mkdir build_input
-$ wget https://archive.apache.org/dist/spark/spark-2.3.0/spark-2.3.0-bin-hadoop2.7.tgz -O build_input/spark-2.3.0-bin-hadoop2.7.tgz
-$ wget https://archive.apache.org/dist/spark/spark-2.3.0/spark-2.3.0-bin-hadoop2.7.tgz.md5 -O build_input/spark-2.3.0-bin-hadoop2.7.tgz.md5
+$ mkdir build-input
+$ wget https://archive.apache.org/dist/spark/spark-2.4.0/spark-2.4.0-bin-hadoop2.7.tgz -O build-input/spark-2.4.0-bin-hadoop2.7.tgz
+$ wget https://archive.apache.org/dist/spark/spark-2.4.0/spark-2.4.0-bin-hadoop2.7.tgz.sha512 -O build-input/spark-2.4.0-bin-hadoop2.7.tgz.sha512
+
+Optionally, your `build-input` directory may contain a modify-spark directory. The structure of this directory should be parallel to the structure
+of the top-level directory in the Spark distribution tarball. The contents of this directory will be copied to the Spark installation using rsync,
+allowing you to add or overwrite files. To add my.jar to Spark, for example, put it in build-input/modify-spark/jars/my.jar
 
 Completing the image with OpenShift:
 ------------------------------------
@@ -58,7 +62,7 @@ Completing the image with OpenShift:
 Run a binary build specifying the spark distribution, for example:
 
 $ oc new-build --name=openshift-spark --docker-image=radanalyticsio/openshift-spark-inc --binary
-$ oc start-build openshift-spark --from-file=https://archive.apache.org/dist/spark/spark-2.3.0/spark-2.3.0-bin-hadoop2.7.tgz
+$ oc start-build openshift-spark --from-file=https://archive.apache.org/dist/spark/spark-2.4.0/spark-2.4.0-bin-hadoop2.7.tgz
 
 This will write the completed image to an imagestream called 'openshift-spark'
 in the current project. Note that the value of --from-file can also be a local
@@ -67,7 +71,7 @@ directory (see Build Inputs above).
 Completing the image with the s2i tool:
 ---------------------------------------
 
-s2i build build_input radanalyticsio/openshift-spark-inc openshift-spark
+s2i build build-input radanalyticsio/openshift-spark-inc openshift-spark
 
 This will build a local image named 'openshift-spark:latest' which can
 then be uploaded to an image repository.

--- a/openshift-spark-build-py36/Dockerfile
+++ b/openshift-spark-build-py36/Dockerfile
@@ -18,33 +18,14 @@
 
 FROM centos:latest
 
-# Environment variables
-ENV JBOSS_IMAGE_NAME="radanalyticsio/openshift-spark" \
-    JBOSS_IMAGE_VERSION="2.4-latest" \
-    SCL_ENABLE_CMD="scl enable rh-python36" \
-    PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/spark/bin" \
-    SPARK_HOME="/opt/spark" \
-    SPARK_INSTALL="/opt/spark-distro" \
-    STI_SCRIPTS_PATH="/usr/libexec/s2i" 
-
-# Labels
-LABEL name="$JBOSS_IMAGE_NAME" \
-      version="$JBOSS_IMAGE_VERSION" \
-      architecture="x86_64"  \
-      com.redhat.component="radanalyticsio-openshift-spark-docker"  \
-      org.concrt.version="1.4.1" \
-      maintainer="Chad Roberts <croberts@redhat.com>" \
-      sparkversion="2.4.0" \
-      io.openshift.s2i.scripts-url="image:///usr/libexec/s2i"
-
-
 USER root
 
 
 # Install required RPMs and ensure that the packages were installed
-RUN yum install -y  java-1.8.0-openjdk wget \
-    && yum clean all && \
-    rpm -q  java-1.8.0-openjdk wget
+RUN yum install -y java-1.8.0-openjdk wget \
+    && yum clean all && rm -rf /var/cache/yum \
+    && rpm -q java-1.8.0-openjdk wget
+
 
 # Add all artifacts to the /tmp/artifacts
 # directory
@@ -52,13 +33,31 @@ COPY \
     spark-2.4.0-bin-hadoop2.7.tgz \
     /tmp/artifacts/
 
+
+# Environment variables
+ENV \
+    JBOSS_IMAGE_NAME="radanalyticsio/openshift-spark" \
+    JBOSS_IMAGE_VERSION="2.4-latest" \
+    PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/spark/bin" \
+    SCL_ENABLE_CMD="scl enable rh-python36" \
+    SPARK_HOME="/opt/spark" \
+    SPARK_INSTALL="/opt/spark-distro" \
+    STI_SCRIPTS_PATH="/usr/libexec/s2i" 
+
+# Labels
+LABEL \
+      io.cekit.version="2.2.7"  \
+      io.openshift.s2i.scripts-url="image:///usr/libexec/s2i"  \
+      maintainer="Chad Roberts <croberts@redhat.com>"  \
+      name="radanalyticsio/openshift-spark"  \
+      org.concrt.version="2.2.7"  \
+      sparkversion="2.4.0"  \
+      version="2.4-latest" 
+
 # Add scripts used to configure the image
 COPY modules /tmp/scripts
 
 # Custom scripts
-USER root
-RUN [ "bash", "-x", "/tmp/scripts/python36/install" ]
-
 USER root
 RUN [ "bash", "-x", "/tmp/scripts/common/install" ]
 
@@ -70,6 +69,9 @@ RUN [ "bash", "-x", "/tmp/scripts/spark/install" ]
 
 USER root
 RUN [ "bash", "-x", "/tmp/scripts/s2i/install" ]
+
+USER root
+RUN [ "bash", "-x", "/tmp/scripts/python36/install" ]
 
 USER root
 RUN rm -rf /tmp/scripts
@@ -84,3 +86,4 @@ WORKDIR /tmp
 ENTRYPOINT ["/entrypoint"]
 
 CMD ["/launch.sh"]
+

--- a/openshift-spark-build-py36/help.md
+++ b/openshift-spark-build-py36/help.md
@@ -1,0 +1,66 @@
+# radanalyticsio/openshift-spark
+
+## Description
+
+
+
+
+## Environment variables
+
+### Informational
+
+These environment variables are defined in the image.
+
+__JBOSS_IMAGE_NAME__
+>"radanalyticsio/openshift-spark"
+
+__JBOSS_IMAGE_VERSION__
+>"2.4-latest"
+
+__PATH__
+>"/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/spark/bin"
+
+__SCL_ENABLE_CMD__
+>"scl enable rh-python36"
+
+__SPARK_HOME__
+>"/opt/spark"
+
+__SPARK_INSTALL__
+>"/opt/spark-distro"
+
+__STI_SCRIPTS_PATH__
+>"/usr/libexec/s2i"
+
+
+### Configuration
+
+The image can be configured by defining these environment variables
+when starting a container:
+
+
+
+## Labels
+
+__io.cekit.version__
+> 2.2.7
+
+__io.openshift.s2i.scripts-url__
+> image:///usr/libexec/s2i
+
+__maintainer__
+> Chad Roberts <croberts@redhat.com>
+
+__name__
+> radanalyticsio/openshift-spark
+
+__org.concrt.version__
+> 2.2.7
+
+__sparkversion__
+> 2.4.0
+
+__version__
+> 2.4-latest
+
+

--- a/openshift-spark-build-py36/modules/s2i/added/assemble
+++ b/openshift-spark-build-py36/modules/s2i/added/assemble
@@ -138,6 +138,12 @@ else
         done
         popd &> /dev/null
 
+	# If someone included mods in a parallel directory, install them with rsync
+        if [ -d "$S2I_SOURCE_DIR/modify-spark" ]; then
+	    echo Found a modify-spark directory, running rsync to install changes
+	    rsync -av "$S2I_SOURCE_DIR/modify-spark/" $SPARK_HOME
+        fi
+
         # Can we run spark-submit?
         $SPARK_HOME/bin/spark-submit --version
         if [ "$?" -eq 0 ]; then

--- a/openshift-spark-build-py36/modules/s2i/added/assemble
+++ b/openshift-spark-build-py36/modules/s2i/added/assemble
@@ -139,7 +139,7 @@ else
         popd &> /dev/null
 
 	# If someone included mods in a parallel directory, install them with rsync
-        if [ -d "$S2I_SOURCE_DIR/modify-spark" ]; then
+        if [ -x /usr/bin/rsync ] && [ -d "$S2I_SOURCE_DIR/modify-spark" ]; then
 	    echo Found a modify-spark directory, running rsync to install changes
 	    rsync -av "$S2I_SOURCE_DIR/modify-spark/" $SPARK_HOME
         fi

--- a/openshift-spark-build-py36/modules/s2i/added/usage
+++ b/openshift-spark-build-py36/modules/s2i/added/usage
@@ -45,12 +45,16 @@ Build inputs:
 
 The OpenShift method can take either local files or a URL as build input.
 For the s2i method, local files are required. Here is an example which
-downloads an Apache Spark distribution to a local 'build_input' directory
-(including the md5 file is optional).
+downloads an Apache Spark distribution to a local 'build-input' directory
+(including the sha512 file is optional).
 
-$ mkdir build_input
-$ wget https://archive.apache.org/dist/spark/spark-2.3.0/spark-2.3.0-bin-hadoop2.7.tgz -O build_input/spark-2.3.0-bin-hadoop2.7.tgz
-$ wget https://archive.apache.org/dist/spark/spark-2.3.0/spark-2.3.0-bin-hadoop2.7.tgz.md5 -O build_input/spark-2.3.0-bin-hadoop2.7.tgz.md5
+$ mkdir build-input
+$ wget https://archive.apache.org/dist/spark/spark-2.4.0/spark-2.4.0-bin-hadoop2.7.tgz -O build-input/spark-2.4.0-bin-hadoop2.7.tgz
+$ wget https://archive.apache.org/dist/spark/spark-2.4.0/spark-2.4.0-bin-hadoop2.7.tgz.sha512 -O build-input/spark-2.4.0-bin-hadoop2.7.tgz.sha512
+
+Optionally, your `build-input` directory may contain a modify-spark directory. The structure of this directory should be parallel to the structure
+of the top-level directory in the Spark distribution tarball. The contents of this directory will be copied to the Spark installation using rsync,
+allowing you to add or overwrite files. To add my.jar to Spark, for example, put it in build-input/modify-spark/jars/my.jar
 
 Completing the image with OpenShift:
 ------------------------------------
@@ -58,7 +62,7 @@ Completing the image with OpenShift:
 Run a binary build specifying the spark distribution, for example:
 
 $ oc new-build --name=openshift-spark --docker-image=radanalyticsio/openshift-spark-inc --binary
-$ oc start-build openshift-spark --from-file=https://archive.apache.org/dist/spark/spark-2.3.0/spark-2.3.0-bin-hadoop2.7.tgz
+$ oc start-build openshift-spark --from-file=https://archive.apache.org/dist/spark/spark-2.4.0/spark-2.4.0-bin-hadoop2.7.tgz
 
 This will write the completed image to an imagestream called 'openshift-spark'
 in the current project. Note that the value of --from-file can also be a local
@@ -67,7 +71,7 @@ directory (see Build Inputs above).
 Completing the image with the s2i tool:
 ---------------------------------------
 
-s2i build build_input radanalyticsio/openshift-spark-inc openshift-spark
+s2i build build-input radanalyticsio/openshift-spark-inc openshift-spark
 
 This will build a local image named 'openshift-spark:latest' which can
 then be uploaded to an image repository.

--- a/openshift-spark-build/Dockerfile
+++ b/openshift-spark-build/Dockerfile
@@ -18,39 +18,41 @@
 
 FROM centos:latest
 
-# Environment variables
-ENV JBOSS_IMAGE_NAME="radanalyticsio/openshift-spark" \
-    JBOSS_IMAGE_VERSION="2.4-latest" \
-    PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/spark/bin" \
-    SPARK_HOME="/opt/spark" \
-    SPARK_INSTALL="/opt/spark-distro" \
-    STI_SCRIPTS_PATH="/usr/libexec/s2i" \
-    SCL_ENABLE_CMD="" 
-
-# Labels
-LABEL name="$JBOSS_IMAGE_NAME" \
-      version="$JBOSS_IMAGE_VERSION" \
-      architecture="x86_64"  \
-      com.redhat.component="radanalyticsio-openshift-spark-docker"  \
-      org.concrt.version="1.4.1" \
-      maintainer="Chad Roberts <croberts@redhat.com>" \
-      sparkversion="2.4.0" \
-      io.openshift.s2i.scripts-url="image:///usr/libexec/s2i"
-
-
 USER root
 
 
 # Install required RPMs and ensure that the packages were installed
-RUN yum install -y  numpy java-1.8.0-openjdk wget \
-    && yum clean all && \
-    rpm -q  numpy java-1.8.0-openjdk wget
+RUN yum install -y java-1.8.0-openjdk wget numpy \
+    && yum clean all && rm -rf /var/cache/yum \
+    && rpm -q java-1.8.0-openjdk wget numpy
+
 
 # Add all artifacts to the /tmp/artifacts
 # directory
 COPY \
     spark-2.4.0-bin-hadoop2.7.tgz \
     /tmp/artifacts/
+
+
+# Environment variables
+ENV \
+    JBOSS_IMAGE_NAME="radanalyticsio/openshift-spark" \
+    JBOSS_IMAGE_VERSION="2.4-latest" \
+    PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/spark/bin" \
+    SCL_ENABLE_CMD="" \
+    SPARK_HOME="/opt/spark" \
+    SPARK_INSTALL="/opt/spark-distro" \
+    STI_SCRIPTS_PATH="/usr/libexec/s2i" 
+
+# Labels
+LABEL \
+      io.cekit.version="2.2.7"  \
+      io.openshift.s2i.scripts-url="image:///usr/libexec/s2i"  \
+      maintainer="Chad Roberts <croberts@redhat.com>"  \
+      name="radanalyticsio/openshift-spark"  \
+      org.concrt.version="2.2.7"  \
+      sparkversion="2.4.0"  \
+      version="2.4-latest" 
 
 # Add scripts used to configure the image
 COPY modules /tmp/scripts
@@ -81,3 +83,4 @@ WORKDIR /tmp
 ENTRYPOINT ["/entrypoint"]
 
 CMD ["/launch.sh"]
+

--- a/openshift-spark-build/help.md
+++ b/openshift-spark-build/help.md
@@ -1,0 +1,66 @@
+# radanalyticsio/openshift-spark
+
+## Description
+
+
+
+
+## Environment variables
+
+### Informational
+
+These environment variables are defined in the image.
+
+__JBOSS_IMAGE_NAME__
+>"radanalyticsio/openshift-spark"
+
+__JBOSS_IMAGE_VERSION__
+>"2.4-latest"
+
+__PATH__
+>"/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/spark/bin"
+
+__SCL_ENABLE_CMD__
+>""
+
+__SPARK_HOME__
+>"/opt/spark"
+
+__SPARK_INSTALL__
+>"/opt/spark-distro"
+
+__STI_SCRIPTS_PATH__
+>"/usr/libexec/s2i"
+
+
+### Configuration
+
+The image can be configured by defining these environment variables
+when starting a container:
+
+
+
+## Labels
+
+__io.cekit.version__
+> 2.2.7
+
+__io.openshift.s2i.scripts-url__
+> image:///usr/libexec/s2i
+
+__maintainer__
+> Chad Roberts <croberts@redhat.com>
+
+__name__
+> radanalyticsio/openshift-spark
+
+__org.concrt.version__
+> 2.2.7
+
+__sparkversion__
+> 2.4.0
+
+__version__
+> 2.4-latest
+
+

--- a/openshift-spark-build/modules/s2i/added/assemble
+++ b/openshift-spark-build/modules/s2i/added/assemble
@@ -138,6 +138,12 @@ else
         done
         popd &> /dev/null
 
+	# If someone included mods in a parallel directory, install them with rsync
+        if [ -d "$S2I_SOURCE_DIR/modify-spark" ]; then
+	    echo Found a modify-spark directory, running rsync to install changes
+	    rsync -av "$S2I_SOURCE_DIR/modify-spark/" $SPARK_HOME
+        fi
+
         # Can we run spark-submit?
         $SPARK_HOME/bin/spark-submit --version
         if [ "$?" -eq 0 ]; then

--- a/openshift-spark-build/modules/s2i/added/assemble
+++ b/openshift-spark-build/modules/s2i/added/assemble
@@ -139,7 +139,7 @@ else
         popd &> /dev/null
 
 	# If someone included mods in a parallel directory, install them with rsync
-        if [ -d "$S2I_SOURCE_DIR/modify-spark" ]; then
+        if [ -x /usr/bin/rsync ] && [ -d "$S2I_SOURCE_DIR/modify-spark" ]; then
 	    echo Found a modify-spark directory, running rsync to install changes
 	    rsync -av "$S2I_SOURCE_DIR/modify-spark/" $SPARK_HOME
         fi

--- a/openshift-spark-build/modules/s2i/added/usage
+++ b/openshift-spark-build/modules/s2i/added/usage
@@ -45,12 +45,16 @@ Build inputs:
 
 The OpenShift method can take either local files or a URL as build input.
 For the s2i method, local files are required. Here is an example which
-downloads an Apache Spark distribution to a local 'build_input' directory
-(including the md5 file is optional).
+downloads an Apache Spark distribution to a local 'build-input' directory
+(including the sha512 file is optional).
 
-$ mkdir build_input
-$ wget https://archive.apache.org/dist/spark/spark-2.3.0/spark-2.3.0-bin-hadoop2.7.tgz -O build_input/spark-2.3.0-bin-hadoop2.7.tgz
-$ wget https://archive.apache.org/dist/spark/spark-2.3.0/spark-2.3.0-bin-hadoop2.7.tgz.md5 -O build_input/spark-2.3.0-bin-hadoop2.7.tgz.md5
+$ mkdir build-input
+$ wget https://archive.apache.org/dist/spark/spark-2.4.0/spark-2.4.0-bin-hadoop2.7.tgz -O build-input/spark-2.4.0-bin-hadoop2.7.tgz
+$ wget https://archive.apache.org/dist/spark/spark-2.4.0/spark-2.4.0-bin-hadoop2.7.tgz.sha512 -O build-input/spark-2.4.0-bin-hadoop2.7.tgz.sha512
+
+Optionally, your `build-input` directory may contain a modify-spark directory. The structure of this directory should be parallel to the structure
+of the top-level directory in the Spark distribution tarball. The contents of this directory will be copied to the Spark installation using rsync,
+allowing you to add or overwrite files. To add my.jar to Spark, for example, put it in build-input/modify-spark/jars/my.jar
 
 Completing the image with OpenShift:
 ------------------------------------
@@ -58,7 +62,7 @@ Completing the image with OpenShift:
 Run a binary build specifying the spark distribution, for example:
 
 $ oc new-build --name=openshift-spark --docker-image=radanalyticsio/openshift-spark-inc --binary
-$ oc start-build openshift-spark --from-file=https://archive.apache.org/dist/spark/spark-2.3.0/spark-2.3.0-bin-hadoop2.7.tgz
+$ oc start-build openshift-spark --from-file=https://archive.apache.org/dist/spark/spark-2.4.0/spark-2.4.0-bin-hadoop2.7.tgz
 
 This will write the completed image to an imagestream called 'openshift-spark'
 in the current project. Note that the value of --from-file can also be a local
@@ -67,7 +71,7 @@ directory (see Build Inputs above).
 Completing the image with the s2i tool:
 ---------------------------------------
 
-s2i build build_input radanalyticsio/openshift-spark-inc openshift-spark
+s2i build build-input radanalyticsio/openshift-spark-inc openshift-spark
 
 This will build a local image named 'openshift-spark:latest' which can
 then be uploaded to an image repository.


### PR DESCRIPTION
This change supports an optional modify-spark directory that
can be put in the build input directory for image completion.
If the modify-spark directory is there, the image completion
script will run rsync to copy it's contents into the spark
install directory. This mechanism allows a user to modify
a spark distro by laying out a parallel directory structure.