### PR TITLE
Travis: calculate the number of layers for images to squash

### DIFF
--- a/.travis.before.install.sh
+++ b/.travis.before.install.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+set -xe
+
+main() {
+  if [[ "${TRAVIS_JOB_NAME}" != "Push container images" ]] || \
+     [[ "${TRAVIS_BRANCH}" = "master" && "${TRAVIS_PULL_REQUEST}" = "false" ]] || \
+     [[ "${TRAVIS_TAG}" =~ ^[0-9]+\.[0-9]+\.[0-9]+-[0-9]+$ ]]; then
+    pwd
+    bash --version
+    sudo apt-get install --only-upgrade bash
+    bash --version
+    ./test/prepare.sh
+  else
+    echo "[Before install] Not doing the ''./test/prepare.sh', because the tag '${TRAVIS_TAG}' is not of form x.y.z-n or we are not building the master branch"
+  fi
+}
+
+main

--- a/.travis.release.images.sh
+++ b/.travis.release.images.sh
@@ -18,7 +18,7 @@ main() {
     loginDockerIo
     pushLatestImages "docker.io"
     loginQuayIo
-    pushLatestImages "quay.io"
+    pushLatestImages "quay.io" 
   elif [[ "${TRAVIS_TAG}" =~ ^[0-9]+\.[0-9]+\.[0-9]+-[0-9]+$ ]]; then
     echo "Squashing and pushing the '${TRAVIS_TAG}' images to docker.io and quay.io"
     buildImages
@@ -60,9 +60,15 @@ squashAndPush() {
   local _in=$1
   local _out=$2
 
-  echo "Squashing $_out.."
-  # squash last 22 layers (everything up to the base centos image)
-  docker-squash -f 22 -t $_out $_in
+  local _layers_total=$(docker history -q $_in | wc -l)
+  local _layers_to_keep=4
+  if ! [[ "$_layers_total" =~ "^[0-9]+$" ]] || [[ "$_layers_total" -le "$_layers_to_keep" ]] ; then
+    echo "error: _layers_total is not a number or lower than or equal to $_layers_to_keep" >&2; exit
+  fi
+  local _last_n=$[_layers_total - _layers_to_keep]
+
+  echo "Squashing $_out (last $_last_n layers).."
+  docker-squash -f $_last_n -t $_out $_in
   docker push $_out
 }
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,11 +9,7 @@ stages:
   - deploy
 
 before_install:
-- pwd
-- bash --version
-- sudo apt-get install --only-upgrade bash
-- bash --version
-- test/prepare.sh
+- ./.travis.before.install.sh
 
 env:
   global: OPENSHIFT_VERSION="v3.10"


### PR DESCRIPTION
* 1 commit is about smarter squashing, where the number of layers to squash is calculated based on the `docker history` command output (instead of hard-coded 22 value as it was)
* and the second commit is more a refactoring where I moved those lines from https://github.com/radanalyticsio/openshift-spark/blob/e8f3c489421a1b36fcee0d0af694a43d8baaa134/.travis.yml#L12:L16 to its own bash script and not running it in the deploy job when it wasn't necessary ... there is no need to install openshift if we wouldn't be pushing the images