### PR TITLE
Change modify-spark behavior for incomplete images and move chmod

### DIFF
--- a/make-build-dir.sh
+++ b/make-build-dir.sh
@@ -15,4 +15,4 @@ make -f Makefile.inc zero-tarballs
 git add openshift-spark-build
 git add openshift-spark-build-py36
 git add openshift-spark-build-inc
-git add openshift-spark-build-inc-py36
+git add openshift-spark-build-py36-inc

--- a/modules/s2i/added/assemble
+++ b/modules/s2i/added/assemble
@@ -106,8 +106,6 @@ else
         fi
 
         ln -s $sparkdir $SPARK_INSTALL/distro
-        # Spark workers need to write to the spark directory to track apps
-        chmod -R g+rwX $sparkdir
 
         # Search for the spark entrypoint file and copy it to $SPARK_INSTALL
         entry=$(find $sparkdir/kubernetes -name entrypoint.sh)
@@ -139,10 +137,15 @@ else
         popd &> /dev/null
 
 	# If someone included mods in a parallel directory, install them with rsync
+        # Don't try to preserve permisions, owner, or group because we don't have
+        # any control over how s2i uploaded the files, so there's no use preserving.
         if [ -x /usr/bin/rsync ] && [ -d "$S2I_SOURCE_DIR/modify-spark" ]; then
 	    echo Found a modify-spark directory, running rsync to install changes
-	    rsync -av "$S2I_SOURCE_DIR/modify-spark/" $SPARK_HOME
+	    rsync -vrltD "$S2I_SOURCE_DIR/modify-spark/" $SPARK_HOME
         fi
+
+        # Spark workers need to write to the spark directory to track apps
+        chmod -R g+rwX $sparkdir
 
         # Can we run spark-submit?
         $SPARK_HOME/bin/spark-submit --version

--- a/openshift-spark-build-inc/modules/s2i/added/assemble
+++ b/openshift-spark-build-inc/modules/s2i/added/assemble
@@ -106,8 +106,6 @@ else
         fi
 
         ln -s $sparkdir $SPARK_INSTALL/distro
-        # Spark workers need to write to the spark directory to track apps
-        chmod -R g+rwX $sparkdir
 
         # Search for the spark entrypoint file and copy it to $SPARK_INSTALL
         entry=$(find $sparkdir/kubernetes -name entrypoint.sh)
@@ -139,10 +137,15 @@ else
         popd &> /dev/null
 
 	# If someone included mods in a parallel directory, install them with rsync
+        # Don't try to preserve permisions, owner, or group because we don't have
+        # any control over how s2i uploaded the files, so there's no use preserving.
         if [ -x /usr/bin/rsync ] && [ -d "$S2I_SOURCE_DIR/modify-spark" ]; then
 	    echo Found a modify-spark directory, running rsync to install changes
-	    rsync -av "$S2I_SOURCE_DIR/modify-spark/" $SPARK_HOME
+	    rsync -vrltD "$S2I_SOURCE_DIR/modify-spark/" $SPARK_HOME
         fi
+
+        # Spark workers need to write to the spark directory to track apps
+        chmod -R g+rwX $sparkdir
 
         # Can we run spark-submit?
         $SPARK_HOME/bin/spark-submit --version

--- a/openshift-spark-build-py36-inc/modules/s2i/added/assemble
+++ b/openshift-spark-build-py36-inc/modules/s2i/added/assemble
@@ -106,8 +106,6 @@ else
         fi
 
         ln -s $sparkdir $SPARK_INSTALL/distro
-        # Spark workers need to write to the spark directory to track apps
-        chmod -R g+rwX $sparkdir
 
         # Search for the spark entrypoint file and copy it to $SPARK_INSTALL
         entry=$(find $sparkdir/kubernetes -name entrypoint.sh)
@@ -139,10 +137,15 @@ else
         popd &> /dev/null
 
 	# If someone included mods in a parallel directory, install them with rsync
+        # Don't try to preserve permisions, owner, or group because we don't have
+        # any control over how s2i uploaded the files, so there's no use preserving.
         if [ -x /usr/bin/rsync ] && [ -d "$S2I_SOURCE_DIR/modify-spark" ]; then
 	    echo Found a modify-spark directory, running rsync to install changes
-	    rsync -av "$S2I_SOURCE_DIR/modify-spark/" $SPARK_HOME
+	    rsync -vrltD "$S2I_SOURCE_DIR/modify-spark/" $SPARK_HOME
         fi
+
+        # Spark workers need to write to the spark directory to track apps
+        chmod -R g+rwX $sparkdir
 
         # Can we run spark-submit?
         $SPARK_HOME/bin/spark-submit --version

--- a/openshift-spark-build-py36/modules/s2i/added/assemble
+++ b/openshift-spark-build-py36/modules/s2i/added/assemble
@@ -106,8 +106,6 @@ else
         fi
 
         ln -s $sparkdir $SPARK_INSTALL/distro
-        # Spark workers need to write to the spark directory to track apps
-        chmod -R g+rwX $sparkdir
 
         # Search for the spark entrypoint file and copy it to $SPARK_INSTALL
         entry=$(find $sparkdir/kubernetes -name entrypoint.sh)
@@ -139,10 +137,15 @@ else
         popd &> /dev/null
 
 	# If someone included mods in a parallel directory, install them with rsync
+        # Don't try to preserve permisions, owner, or group because we don't have
+        # any control over how s2i uploaded the files, so there's no use preserving.
         if [ -x /usr/bin/rsync ] && [ -d "$S2I_SOURCE_DIR/modify-spark" ]; then
 	    echo Found a modify-spark directory, running rsync to install changes
-	    rsync -av "$S2I_SOURCE_DIR/modify-spark/" $SPARK_HOME
+	    rsync -vrltD "$S2I_SOURCE_DIR/modify-spark/" $SPARK_HOME
         fi
+
+        # Spark workers need to write to the spark directory to track apps
+        chmod -R g+rwX $sparkdir
 
         # Can we run spark-submit?
         $SPARK_HOME/bin/spark-submit --version

--- a/openshift-spark-build/modules/s2i/added/assemble
+++ b/openshift-spark-build/modules/s2i/added/assemble
@@ -106,8 +106,6 @@ else
         fi
 
         ln -s $sparkdir $SPARK_INSTALL/distro
-        # Spark workers need to write to the spark directory to track apps
-        chmod -R g+rwX $sparkdir
 
         # Search for the spark entrypoint file and copy it to $SPARK_INSTALL
         entry=$(find $sparkdir/kubernetes -name entrypoint.sh)
@@ -139,10 +137,15 @@ else
         popd &> /dev/null
 
 	# If someone included mods in a parallel directory, install them with rsync
+        # Don't try to preserve permisions, owner, or group because we don't have
+        # any control over how s2i uploaded the files, so there's no use preserving.
         if [ -x /usr/bin/rsync ] && [ -d "$S2I_SOURCE_DIR/modify-spark" ]; then
 	    echo Found a modify-spark directory, running rsync to install changes
-	    rsync -av "$S2I_SOURCE_DIR/modify-spark/" $SPARK_HOME
+	    rsync -vrltD "$S2I_SOURCE_DIR/modify-spark/" $SPARK_HOME
         fi
+
+        # Spark workers need to write to the spark directory to track apps
+        chmod -R g+rwX $sparkdir
 
         # Can we run spark-submit?
         $SPARK_HOME/bin/spark-submit --version


### PR DESCRIPTION
The rsync command used to enable the "modify-spark" behavior
in incomplete images was preserving permissions. However, it
was preserving permissions on files as uploaded by s2i, which
can't be relied on (it's not necessarily the same as perms on
disk from build_input). Therefore, preserving permissiosn has been
dropped, and a chmod to add group rwX to the spark installation
was moved until after the rsync.