### PR TITLE
Add SCL_ENABLE_CMD to spark-on-k8s entrypoint commands

### DIFF
--- a/modules/common/added/scripts/entrypoint
+++ b/modules/common/added/scripts/entrypoint
@@ -67,11 +67,19 @@ function patch_uid {
 # standard spark entrypoint
 case "$1" in
     driver | executor | init)
-        $SPARK_INSTALL/entrypoint.sh $CMD &
+        if [ -z "$SCL_ENABLE_CMD" ]; then
+            $SPARK_INSTALL/entrypoint.sh $CMD
+        else
+            $SCL_ENABLE_CMD -- $SPARK_INSTALL/entrypoint.sh $CMD &
+        fi
         ;;
     *)
         patch_uid
-        $SCL_ENABLE_CMD $CMD &
+        if [ -z "$SCL_ENABLE_CMD" ]; then
+            $CMD &
+        else
+            $SCL_ENABLE_CMD -- $CMD &
+        fi
         ;;
 esac
 PID=$!

--- a/openshift-spark-build-inc/modules/common/added/scripts/entrypoint
+++ b/openshift-spark-build-inc/modules/common/added/scripts/entrypoint
@@ -67,11 +67,19 @@ function patch_uid {
 # standard spark entrypoint
 case "$1" in
     driver | executor | init)
-        $SPARK_INSTALL/entrypoint.sh $CMD &
+        if [ -z "$SCL_ENABLE_CMD" ]; then
+            $SPARK_INSTALL/entrypoint.sh $CMD
+        else
+            $SCL_ENABLE_CMD -- $SPARK_INSTALL/entrypoint.sh $CMD &
+        fi
         ;;
     *)
         patch_uid
-        $SCL_ENABLE_CMD $CMD &
+        if [ -z "$SCL_ENABLE_CMD" ]; then
+            $CMD &
+        else
+            $SCL_ENABLE_CMD -- $CMD &
+        fi
         ;;
 esac
 PID=$!

--- a/openshift-spark-build-py36-inc/modules/common/added/scripts/entrypoint
+++ b/openshift-spark-build-py36-inc/modules/common/added/scripts/entrypoint
@@ -67,11 +67,19 @@ function patch_uid {
 # standard spark entrypoint
 case "$1" in
     driver | executor | init)
-        $SPARK_INSTALL/entrypoint.sh $CMD &
+        if [ -z "$SCL_ENABLE_CMD" ]; then
+            $SPARK_INSTALL/entrypoint.sh $CMD
+        else
+            $SCL_ENABLE_CMD -- $SPARK_INSTALL/entrypoint.sh $CMD &
+        fi
         ;;
     *)
         patch_uid
-        $SCL_ENABLE_CMD $CMD &
+        if [ -z "$SCL_ENABLE_CMD" ]; then
+            $CMD &
+        else
+            $SCL_ENABLE_CMD -- $CMD &
+        fi
         ;;
 esac
 PID=$!

--- a/openshift-spark-build-py36/modules/common/added/scripts/entrypoint
+++ b/openshift-spark-build-py36/modules/common/added/scripts/entrypoint
@@ -67,11 +67,19 @@ function patch_uid {
 # standard spark entrypoint
 case "$1" in
     driver | executor | init)
-        $SPARK_INSTALL/entrypoint.sh $CMD &
+        if [ -z "$SCL_ENABLE_CMD" ]; then
+            $SPARK_INSTALL/entrypoint.sh $CMD
+        else
+            $SCL_ENABLE_CMD -- $SPARK_INSTALL/entrypoint.sh $CMD &
+        fi
         ;;
     *)
         patch_uid
-        $SCL_ENABLE_CMD $CMD &
+        if [ -z "$SCL_ENABLE_CMD" ]; then
+            $CMD &
+        else
+            $SCL_ENABLE_CMD -- $CMD &
+        fi
         ;;
 esac
 PID=$!

--- a/openshift-spark-build/modules/common/added/scripts/entrypoint
+++ b/openshift-spark-build/modules/common/added/scripts/entrypoint
@@ -67,11 +67,19 @@ function patch_uid {
 # standard spark entrypoint
 case "$1" in
     driver | executor | init)
-        $SPARK_INSTALL/entrypoint.sh $CMD &
+        if [ -z "$SCL_ENABLE_CMD" ]; then
+            $SPARK_INSTALL/entrypoint.sh $CMD
+        else
+            $SCL_ENABLE_CMD -- $SPARK_INSTALL/entrypoint.sh $CMD &
+        fi
         ;;
     *)
         patch_uid
-        $SCL_ENABLE_CMD $CMD &
+        if [ -z "$SCL_ENABLE_CMD" ]; then
+            $CMD &
+        else
+            $SCL_ENABLE_CMD -- $CMD &
+        fi
         ;;
 esac
 PID=$!


### PR DESCRIPTION
This is necessary to cause py36 to be the active version
for spark-on-k8s invocations of the openshift-spark images
that support py36.