### PR TITLE
Change the tagging of x.y-latest to just x.y

### DIFF
--- a/.travis.release.images.sh
+++ b/.travis.release.images.sh
@@ -98,10 +98,10 @@ pushReleaseImages() {
 
     squashAndPush $image $_fully_qualified_image
 
-    # tag and push also x.y-latest image
-    local _x_y_z_latest=`echo ${TRAVIS_TAG} | sed -r 's;([[:digit:]]+\.[[:digit:]]+).*;\1-latest;'`
-    docker tag $_fully_qualified_image ${REPO}/${OWNER}/${image}:${_x_y_z_latest}
-    docker push ${REPO}/${OWNER}/${image}:${_x_y_z_latest}
+    # tag and push "x.y" image which acts as a "latest" for all  major.minor.Z versions
+    local _x_y_latest=`echo ${TRAVIS_TAG} | sed -r 's;([[:digit:]]+\.[[:digit:]]+).*;\1;'`
+    docker tag $_fully_qualified_image ${REPO}/${OWNER}/${image}:${_x_y_latest}
+    docker push ${REPO}/${OWNER}/${image}:${_x_y_latest}
 
     # tag and push also :latest image
     docker tag $_fully_qualified_image ${REPO}/${OWNER}/${image}:latest


### PR DESCRIPTION
We tag images with x.y.z, and have a movable x.y-latest tag
that references the most recent x.y.z. Change the convention
and drop the -latest, just creating a movable x.y.

This will help deprecate some existing tools that rely on
x.y-latest, so that those versions will be effectively frozen.